### PR TITLE
Remove underline on social links in footer

### DIFF
--- a/includes/news/browser/footer.php
+++ b/includes/news/browser/footer.php
@@ -1,14 +1,14 @@
 <tr>
 	<td style="padding-bottom: 20px; padding-top: 60px; padding-left: 0; padding-right: 0; text-align: center;" align="center">
-		<a href="https://www.facebook.com/ucf/">
+		<a href="https://www.facebook.com/ucf/" style="text-decoration: none;">
 			<img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/social/facebook-circle.png" alt="Facebook" align="center" class="float-center" style="display:inline-block; padding-right: 8px;" width="42" height="42"></a>
-		<a href="https://www.twitter.com/UCF/">
+		<a href="https://www.twitter.com/UCF/" style="text-decoration: none;">
 			<img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/social/twitter-circle.png" alt="Twitter" align="center" class="float-center" style="display:inline-block; padding-right: 8px;" width="42" height="42"></a>
-		<a href="https://www.instagram.com/ucf.edu">
+		<a href="https://www.instagram.com/ucf.edu" style="text-decoration: none;">
 			<img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/social/instagram-circle.png" alt="Instagram" align="center" class="float-center" style="display:inline-block; padding-right: 8px;" width="42" height="42"></a>
-		<a href="https://www.linkedin.com/edu/university-of-central-florida-18118">
+		<a href="https://www.linkedin.com/edu/university-of-central-florida-18118" style="text-decoration: none;">
 			<img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/social/linkedin-circle.png" alt="LinkedIn" align="center" class="float-center" style="display:inline-block; padding-right: 8px;" width="42" height="42"></a>
-		<a href="https://www.youtube.com/user/UCF/">
+		<a href="https://www.youtube.com/user/UCF/" style="text-decoration: none;">
 			<img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/social/youtube-circle.png" alt="YouTube" align="center" class="float-center" style="display:inline-block;" width="42" height="42"></a>
 	</td>
 </tr>

--- a/includes/news/mail/footer.php
+++ b/includes/news/mail/footer.php
@@ -1,14 +1,14 @@
 <tr>
 	<td style="padding-bottom: 20px; padding-top: 60px; padding-left: 0; padding-right: 0; text-align: center;" align="center">
-		<a href="https://www.facebook.com/ucf/">
+		<a href="https://www.facebook.com/ucf/" style="text-decoration: none;">
 			<img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/social/facebook-circle.png" alt="Facebook" align="center" class="float-center" style="display:inline-block; padding-right: 8px;" width="42" height="42"></a>
-		<a href="https://www.twitter.com/UCF/">
+		<a href="https://www.twitter.com/UCF/" style="text-decoration: none;">
 			<img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/social/twitter-circle.png" alt="Twitter" align="center" class="float-center" style="display:inline-block; padding-right: 8px;" width="42" height="42"></a>
-		<a href="https://www.instagram.com/ucf.edu">
+		<a href="https://www.instagram.com/ucf.edu" style="text-decoration: none;">
 			<img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/social/instagram-circle.png" alt="Instagram" align="center" class="float-center" style="display:inline-block; padding-right: 8px;" width="42" height="42"></a>
-		<a href="https://www.linkedin.com/edu/university-of-central-florida-18118">
+		<a href="https://www.linkedin.com/edu/university-of-central-florida-18118" style="text-decoration: none;">
 			<img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/social/linkedin-circle.png" alt="LinkedIn" align="center" class="float-center" style="display:inline-block; padding-right: 8px;" width="42" height="42"></a>
-		<a href="https://www.youtube.com/user/UCF/">
+		<a href="https://www.youtube.com/user/UCF/" style="text-decoration: none;">
 			<img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/social/youtube-circle.png" alt="YouTube" align="center" class="float-center" style="display:inline-block;" width="42" height="42"></a>
 	</td>
 </tr>


### PR DESCRIPTION
Fixes an issue where the underline is shown in the preview emails between the social link images.

Tested by sending a preview email of dev to webcom.