### PR TITLE
Announcements

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -723,7 +723,7 @@ function get_announcement_details( $announcement_ids=array() ) {
 		 * through, then we're done and can return out.
 		 */
 		if ( count( $announcements ) > 0 ) {
-			return array_slice( $announcements, 0, 3 );
+			return $announcements;
 		}
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -35,7 +35,7 @@ define('MAIN_SITE_STORIES_RSS_URL', !empty($theme_options['main_site_stories_url
 define('MAIN_SITE_STORIES_MORE_URL', 'https://today.ucf.edu/');
 define('MAIN_SITE_STORIES_TIMEOUT', 15); // seconds
 
-define('ANNOUNCEMENTS_JSON_URL', !empty($theme_options['announcements_url']) ? $theme_options['announcements_url'] : 'https://www.ucf.edu/announcements/?time=thisweek&exclude_ongoing=True&format=json');
+define('ANNOUNCEMENTS_JSON_URL', !empty($theme_options['announcements_url']) ? $theme_options['announcements_url'] : 'https://www.ucf.edu/announcements/api/announcements/?time=thisweek&exclude_ongoing=True&format=json');
 define('ANNOUNCEMENTS_MORE_URL', 'https://www.ucf.edu/announcements/');
 
 define('IN_THE_NEWS_JSON_URL', !empty($theme_options['in_the_news_url']) ? $theme_options['in_the_news_url'] : 'https://today.ucf.edu/wp-json/ucf-news/v1/external-stories/');
@@ -696,7 +696,8 @@ function get_announcement_details( $announcement_ids=array() ) {
 	 */
 
 	// Slice up the default URL to remove query params and trailing slash
-	$base_url = preg_replace( "/\/\?.*/", "", ANNOUNCEMENTS_JSON_URL );
+	$base_url       = preg_replace( "/\/\?.*/", "", ANNOUNCEMENTS_JSON_URL );
+	$front_base_url = preg_replace( "/^(.*)(.*\/api).*$/", "$1", ANNOUNCEMENTS_JSON_URL );
 
 	if ( ! empty( $announcement_ids ) ) {
 		foreach( $announcement_ids as $announcement_id ) {
@@ -706,7 +707,7 @@ function get_announcement_details( $announcement_ids=array() ) {
 				$announcements,
 				array(
 					'title' => sanitize_for_email( $item->title ),
-					'permalink' => ANNOUNCEMENTS_MORE_URL . $item->slug
+					'permalink' => "$front_base_url/$item->slug"
 				)
 			);
 		}
@@ -734,7 +735,7 @@ function get_announcement_details( $announcement_ids=array() ) {
 				$announcements,
 				array(
 					'title'     => sanitize_for_email( $item->title ),
-					'permalink' => ANNOUNCEMENTS_MORE_URL . $item->slug
+					'permalink' => "$front_base_url/$item->slug"
 				)
 			);
 		}

--- a/functions.php
+++ b/functions.php
@@ -701,8 +701,14 @@ function get_announcement_details( $announcement_ids=array() ) {
 
 	if ( ! empty( $announcement_ids ) ) {
 		foreach( $announcement_ids as $announcement_id ) {
-			$response = wp_remote_get( "$base_url/$announcement_id/", array( 'timeout' => 5 ) );
+			$response      = wp_remote_get( "$base_url/$announcement_id/", array( 'timeout' => 5 ) );
+			$response_code = wp_remote_retrieve_response_code( $response );
+
+			// Continue loop if error code is returned
+			if ( $response_code > 400 ) continue;
+
 			$item = json_decode( wp_remote_retrieve_body( $response ) );
+
 			array_push(
 				$announcements,
 				array(

--- a/functions.php
+++ b/functions.php
@@ -732,9 +732,10 @@ function get_announcement_details( $announcement_ids=array() ) {
 	 * If specific announcements weren't provided,
 	 * go ahead and retrieve announcements normally.
 	 */
-	$response = wp_remote_get( ANNOUNCEMENTS_JSON_URL );
+	$response      = wp_remote_get( ANNOUNCEMENTS_JSON_URL );
+	$response_code = wp_remote_retrieve_response_code( $response );
 
-	if( is_array( $response ) ) {
+	if( is_array( $response ) && $response_code < 400 ) {
 		$items = json_decode( wp_remote_retrieve_body( $response ) );
 		foreach($items as $item) {
 			array_push(

--- a/includes/news/mail/announcements.php
+++ b/includes/news/mail/announcements.php
@@ -1,5 +1,12 @@
 <?php
-$announcements = get_announcement_details();
+$gmucf_content = get_gmucf_email_options_feed_values();
+$announcements = array();
+
+if ( $gmucf_content->gmucf_announcements ) {
+	$announcements = get_announcement_details( $gmucf_content->gmucf_announcements );
+} else {
+	$announcements = get_announcement_details();
+}
 
 if ( count( $announcements ) != 0 ) :
 ?>


### PR DESCRIPTION
Enhancements:
* Updated Announcements logic to look for an array of announcement ids in the `$gmucf_content` pulled from the UCF Today GMUCF Email options (see [Today-Bootstrap #35](https://github.com/UCF/Today-Bootstrap/pull/35) for more information). Falls back to the first 3 announcements found in the general feed if no values are provided.

Bug Fixes:
* Corrected the Announcements JSON Feed option default.