### PR TITLE
HF: Add width restrictions to spotlight image

### DIFF
--- a/functions-email-markup.php
+++ b/functions-email-markup.php
@@ -196,7 +196,7 @@ function gmucf_spotlight_markup( $content ) {
 								<tr>
 									<td style="padding-left: 0; padding-right: 0;">
 										<a href="<?php echo $spotlight_link . ANALYTICS_PARAMS; ?>" style="color: #000; text-decoration: none;" alt="<?php echo $spotlight_alt; ?>">
-											<img class="responsiveimg" border="0" style="border:none;" src="<?php echo $spotlight_image; ?>" />
+											<img class="responsiveimg" border="0" width="600" style="border:none; max-width: 600px;" src="<?php echo $spotlight_image; ?>" />
 										</a>
 									</td>
 								</tr>


### PR DESCRIPTION
Similar to #52, except now I'm adding the styles to the spotlight markup.
Changes viewable in QA.