### PR TITLE
Fix share links for two col stories

### DIFF
--- a/functions-email-markup.php
+++ b/functions-email-markup.php
@@ -162,7 +162,7 @@ function gmucf_featured_story_markup( $content, $social_share ) {
 				</td>
 			</tr>
 			<?php if ( $social_share ) : ?>
-				<?php echo display_social_share( $permalink, $title ); ?>
+				<?php echo display_social_share( $story_permalink, $story_title ); ?>
 			<?php endif; ?>
 		</table>
 	</th>


### PR DESCRIPTION
The share links for the stories displayed in two columns are currently broken, this fixes that by correcting the variable name so that the permalink and title data is passed to the `display_social_share()` function correctly.