### PR TITLE
Update today.ucf.edu URLs

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -28,18 +28,18 @@ define('EVENTS_CALENDAR_ID', 1);
 define('EVENTS_LIMIT', !empty($theme_options['events_limit']) ? $theme_options['events_limit'] : 25);
 define('EVENTS_CACHE_DURATION', 60 * 10); // seconds
 
-define('GMUCF_EMAIL_OPTIONS_JSON_URL', !empty($theme_options['gmucf_email_options_url']) ? $theme_options['gmucf_email_options_url'] : 'https://today.ucf.edu/wp-json/ucf-news/v1/gmucf-email-options/');
+define('GMUCF_EMAIL_OPTIONS_JSON_URL', !empty($theme_options['gmucf_email_options_url']) ? $theme_options['gmucf_email_options_url'] : 'https://www.ucf.edu/news/wp-json/ucf-news/v1/gmucf-email-options/');
 define('GMUCF_EMAIL_OPTIONS_JSON_TIMEOUT', 15); //seconds
 
-define('MAIN_SITE_STORIES_RSS_URL', !empty($theme_options['main_site_stories_url']) ? $theme_options['main_site_stories_url'] : 'https://today.ucf.edu/tag/main-site-stories/feed/');
-define('MAIN_SITE_STORIES_MORE_URL', 'https://today.ucf.edu/');
+define('MAIN_SITE_STORIES_RSS_URL', !empty($theme_options['main_site_stories_url']) ? $theme_options['main_site_stories_url'] : 'https://www.ucf.edu/news/feed/');
+define('MAIN_SITE_STORIES_MORE_URL', 'https://www.ucf.edu/news/');
 define('MAIN_SITE_STORIES_TIMEOUT', 15); // seconds
 
 define('ANNOUNCEMENTS_JSON_URL', !empty($theme_options['announcements_url']) ? $theme_options['announcements_url'] : 'https://www.ucf.edu/announcements/api/announcements/?time=thisweek&exclude_ongoing=True&format=json');
 define('ANNOUNCEMENTS_MORE_URL', 'https://www.ucf.edu/announcements/');
 
-define('IN_THE_NEWS_JSON_URL', !empty($theme_options['in_the_news_url']) ? $theme_options['in_the_news_url'] : 'https://today.ucf.edu/wp-json/ucf-news/v1/external-stories/');
-define('IN_THE_NEWS_MORE_URL', 'https://today.ucf.edu/in-the-news/');
+define('IN_THE_NEWS_JSON_URL', !empty($theme_options['in_the_news_url']) ? $theme_options['in_the_news_url'] : 'https://www.ucf.edu/news/wp-json/ucf-news/v1/external-stories/');
+define('IN_THE_NEWS_MORE_URL', 'https://www.ucf.edu/news/in-the-news/');
 define('IN_THE_NEWS_ITEM_COUNT', !empty($theme_options['in_the_news_item_count']) ? $theme_options['in_the_news_item_count'] : 4);
 define('IN_THE_NEWS_JSON_TIMEOUT', 15); //seconds
 
@@ -102,15 +102,15 @@ Config::$theme_settings = array(
 		new TextField(array(
 			'name'        => 'GMUCF Email Options Feed URL',
 			'id'          => THEME_OPTIONS_NAME.'[gmucf_email_options_url]',
-			'description' => 'URL to the UCF Today GMUCF Email Options feed. Useful for development when testing on different environments. Defaults to <code>https://today.ucf.edu/wp-json/ucf-news/v1/gmucf-email-options/</code>',
-			'default'     => 'https://today.ucf.edu/wp-json/ucf-news/v1/gmucf-email-options/',
+			'description' => 'URL to the UCF Today GMUCF Email Options feed. Useful for development when testing on different environments. Defaults to <code>https://www.ucf.edu/news/wp-json/ucf-news/v1/gmucf-email-options/</code>',
+			'default'     => 'https://www.ucf.edu/news/wp-json/ucf-news/v1/gmucf-email-options/',
 			'value'       => GMUCF_EMAIL_OPTIONS_JSON_URL,
 		)),
 		new TextField(array(
 			'name'        => 'Main Site Stories Feed URL',
 			'id'          => THEME_OPTIONS_NAME.'[main_site_stories_url]',
-			'description' => 'URL to the UCF Today Main Site Stories feed. This feed\'s content is used if the GMUCF Email Options feed\'s <code>send_date</code> value does not match today\'s date. Useful for development when testing on different environments. Defaults to <code>https://today.ucf.edu/tag/main-site-stories/feed/</code>',
-			'default'     => 'https://today.ucf.edu/tag/main-site-stories/feed/',
+			'description' => 'URL to the UCF Today Main Site Stories feed. This feed\'s content is used if the GMUCF Email Options feed\'s <code>send_date</code> value does not match today\'s date. Useful for development when testing on different environments. Defaults to <code>https://www.ucf.edu/news/feed/</code>',
+			'default'     => 'https://www.ucf.edu/news/feed/',
 			'value'       => MAIN_SITE_STORIES_RSS_URL,
 		)),
 	),
@@ -127,8 +127,8 @@ Config::$theme_settings = array(
 		new TextField(array(
 			'name'        => 'In The News JSON URL',
 			'id'          => THEME_OPTIONS_NAME.'[in_the_news_url]',
-			'description' => 'URL of the external-stories feed on UCF Today. Defaults to <code>https://today.ucf.edu/wp-json/ucf-news/v1/external-stories/</code>',
-			'default'     => 'https://today.ucf.edu/wp-json/ucf-news/v1/external-stories/',
+			'description' => 'URL of the external-stories feed on UCF Today. Defaults to <code>https://www.ucf.edu/news/wp-json/ucf-news/v1/external-stories/</code>',
+			'default'     => 'https://www.ucf.edu/news/wp-json/ucf-news/v1/external-stories/',
 			'value'       => IN_THE_NEWS_JSON_URL
 		)),
 		new TextField(array(
@@ -1103,7 +1103,7 @@ function display_social_share( $permalink, $title ) {
 			<span class="montserratlight" style="color: #757575; font-family: Helvetica, Arial, sans-serif; font-weight: 400; font-size: 16px; line-height: 21px; vertical-align: top; padding-right: 6px;">Share: </span>
 			<a href="http://www.facebook.com/sharer.php?u=<?php echo $permalink; ?>" style="display: inline-block; height: 20px; width: 20px; padding-right: 6px;"><img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/social/facebook-share.png" alt="Share on Facebook" width="20" height="20"></a>
 			<a href="https://twitter.com/intent/tweet?text=<?php echo $title; ?>&url=<?php echo $permalink; ?>" style="display: inline-block; height: 20px; width: 20px; padding-right: 6px;"><img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/social/twitter-share.png" alt="Share on Twitter" width="20" height="20"></a>
-			<a href="http://www.linkedin.com/shareArticle?mini=true&url=<?php echo $permalink; ?>&title=<?php echo $title; ?>&source=today.ucf.edu" style="display: inline-block; height: 20px; width: 20px;"><img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/social/linkedin-share.png" alt="Share on LinkedIn" width="20" height="20"></a>
+			<a href="http://www.linkedin.com/shareArticle?mini=true&url=<?php echo $permalink; ?>&title=<?php echo $title; ?>&source=ucf.edu" style="display: inline-block; height: 20px; width: 20px;"><img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/social/linkedin-share.png" alt="Share on LinkedIn" width="20" height="20"></a>
 		</td>
 	</tr>
 	<?php

--- a/includes/news/browser/footer.php
+++ b/includes/news/browser/footer.php
@@ -45,6 +45,6 @@
 
 <tr>
 	<td class="montserratbold" style="text-align: center; padding-bottom: 20px; padding-left: 0; padding-right: 0; font-family: Helvetica, Arial, sans-serif; font-size: 13px; font-weight: bold; color: #000; text-transform: uppercase;" align="center">
-		<a href="https://today.ucf.edu/suggest-a-story/">Suggest a Story</a> <span style="color: #aaa; font-weight: normal; padding-left: 5px; padding-right: 5px;"> | </span> <a href="https://today.ucf.edu/tell-us-what-you-think/">Tell Us What You Think</a>
+		<a href="https://www.ucf.edu/news/suggest-a-story/">Suggest a Story</a> <span style="color: #aaa; font-weight: normal; padding-left: 5px; padding-right: 5px;"> | </span> <a href="https://www.ucf.edu/news/tell-us-what-you-think/">Tell Us What You Think</a>
 	</td>
 </tr>

--- a/includes/news/browser/header.php
+++ b/includes/news/browser/header.php
@@ -1,7 +1,7 @@
 <table class="tableCollapse" width="100%" border="0" align="center" cellpadding="0" bgcolor="#FFF" cellspacing="0" style="width:100%; margin:0; background-color:#fff;">
 	<tr>
 		<td style="padding-top: 20px; padding-bottom: 20px; padding-left: 0; padding-right: 0; text-align: center; border-bottom: 3px solid #fc0;">
-			<a href="https://today.ucf.edu"><img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/logo-today.png" alt="UCF Today" border="0" width="250" height="34"></a>
+			<a href="https://www.ucf.edu/news/"><img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/logo-today.png" alt="UCF Today" border="0" width="250" height="34"></a>
 		</td>
 	</tr>
 

--- a/includes/news/mail/footer.php
+++ b/includes/news/mail/footer.php
@@ -45,7 +45,7 @@
 
 <tr>
 	<td class="montserratbold" style="text-align: center; padding-bottom: 20px; padding-left: 0; padding-right: 0; font-family: Helvetica, Arial, sans-serif; font-size: 13px; font-weight: bold; color: #000; text-transform: uppercase;" align="center">
-		<a href="https://today.ucf.edu/suggest-a-story/">Suggest a Story</a> <span style="color: #aaa; font-weight: normal; padding-left: 5px; padding-right: 5px;"> | </span> <a href="https://today.ucf.edu/tell-us-what-you-think/">Tell Us What You Think</a>
+		<a href="https://www.ucf.edu/news/suggest-a-story/">Suggest a Story</a> <span style="color: #aaa; font-weight: normal; padding-left: 5px; padding-right: 5px;"> | </span> <a href="https://www.ucf.edu/news/tell-us-what-you-think/">Tell Us What You Think</a>
 	</td>
 </tr>
 

--- a/includes/news/mail/header.php
+++ b/includes/news/mail/header.php
@@ -1,7 +1,7 @@
 <table class="tableCollapse" width="100%" border="0" align="center" cellpadding="0" bgcolor="#FFF" cellspacing="0" style="width:100%; margin:0; background-color:#fff;">
 	<tr>
 		<td style="padding-top: 20px; padding-bottom: 20px; padding-left: 0; padding-right: 0; text-align: center; border-bottom: 3px solid #fc0;">
-			<a href="https://today.ucf.edu"><img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/logo-today.png" alt="UCF Today" border="0" width="250" height="34"></a>
+			<a href="https://www.ucf.edu/news/"><img src="<?php echo bloginfo( 'stylesheet_directory' ); ?>/static/img/logo-today.png" alt="UCF Today" border="0" width="250" height="34"></a>
 		</td>
 	</tr>
 


### PR DESCRIPTION
This updates all `today.ucf.edu` URLs to their new location at `ucf.edu/news`

Note: The `MAIN_SITE_STORIES_RSS_URL` will need to probably be either updated to `https://www.ucf.edu/news/wp-json/ucf-news/v1/main-site-stories/` or `https://www.ucf.edu/news/wp-json/wp/v2/posts/`; however, we need to update the fallback template first to be able to retrieve the story data from whichever feed we choose. I'll open an issue for that. For right now, the feed that it's been updated to in this PR (`https://www.ucf.edu/news/feed/`) at least loads the story title and description in the fallback email template. 
