### PR TITLE
Update Analytics Parameters

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -15,7 +15,7 @@ define('THEME_CSS_URL', THEME_STATIC_URL.'/css');
 define('THEME_OPTIONS_GROUP', 'settings');
 define('THEME_OPTIONS_NAME', 'theme');
 define('THEME_OPTIONS_PAGE_TITLE', 'Theme Options');
-define('ANALYTICS_PARAMS', '?utm_source=gmucf&utm_medium=email&utm_campaign=' . date("Y-m-d"));
+define('ANALYTICS_PARAMS', '?utm_source=gmucf&utm_medium=email&utm_campaign=news_announcement_email&utm_content=' . date("Y-m-d"));
 
 $theme_options = get_option( THEME_OPTIONS_NAME );
 


### PR DESCRIPTION
Updates the analytics parameters to set `utm_campaign` to `news_announcement_email` and `utm_content` to the date. Kim requested this change in order to better organize the data in Analytics so that the emails are grouped in one campaign and then dates can be dialed down into from there.