### PR TITLE
Added missing UTM params to in the news, announcements links

### DIFF
--- a/includes/email-markup-functions.php
+++ b/includes/email-markup-functions.php
@@ -110,7 +110,7 @@ function gmucf_featured_stories_row_markup( $stories, $social_share, $more_stori
 				<?php if ( $more_stories_link ) : ?>
 					<tr>
 						<td class="montserratbold" style="text-align: right; padding-top: 0; padding-bottom: 50px; padding-right: 10px; padding-left: 10px; font-family: Helvetica, Arial, sans-serif; font-weight: bold; text-transform: uppercase;" align="right">
-							<a href="<?php echo $more_stories_url; ?>">
+							<a href="<?php echo Analytics\format_url_news_announcements_utm_params( $more_stories_url ); ?>">
 								More UCF Stories
 							</a>
 						</td>

--- a/template-parts/news/mail/announcements.php
+++ b/template-parts/news/mail/announcements.php
@@ -24,7 +24,7 @@ if ( count( $announcements ) !== 0 ) :
 				<?php if ( $announcements_more_url ): ?>
 				<tr>
 					<td class="montserratbold" style="padding-top: 0; padding-bottom: 30px; padding-left: 0; padding-right: 0; font-family: Helvetica, Arial, sans-serif; font-size: 22px; font-weight: bold; color: #006699; text-transform: uppercase; letter-spacing: 1.3px;" align="left">
-						<a href="<?php echo $announcements_more_url; ?>" style="text-decoration: none;">Announcements</a>
+						<a href="<?php echo Analytics\format_url_news_announcements_utm_params( $announcements_more_url ); ?>" style="text-decoration: none;">Announcements</a>
 					</td>
 				</tr>
 				<?php endif; ?>
@@ -41,7 +41,7 @@ if ( count( $announcements ) !== 0 ) :
 									<tbody>
 									<tr>
 										<td style="padding-bottom: 4px;">
-											<a class="montserratsemibold" style="font-family: Helvetica, Arial, sans-serif; font-size: 18px; color: #000000; font-weight: 500;" href="<?php echo $permalink; ?>">
+											<a class="montserratsemibold" style="font-family: Helvetica, Arial, sans-serif; font-size: 18px; color: #000000; font-weight: 500;" href="<?php echo Analytics\format_url_news_announcements_utm_params( $permalink ); ?>">
 												<?php echo $title; ?>
 											</a>
 										</td>

--- a/template-parts/news/mail/backup/featured-stories.php
+++ b/template-parts/news/mail/backup/featured-stories.php
@@ -66,7 +66,7 @@ $more_stories_url = get_option( 'main_site_stories_more_url' );
 	<?php if ( $more_stories_url ): ?>
 	<tr>
 		<td class="montserratbold" style="text-align: right; padding-top: 0; padding-bottom: 50px; padding-right: 10px; padding-left: 10px; font-family: Helvetica, Arial, sans-serif; font-weight: bold; text-transform: uppercase;" align="right">
-			<a href="<?php echo $more_stories_url; ?>">
+			<a href="<?php echo Analytics\format_url_news_announcements_utm_params( $more_stories_url ); ?>">
 				More UCF Stories
 			</a>
 		</td>

--- a/template-parts/news/mail/in-the-news.php
+++ b/template-parts/news/mail/in-the-news.php
@@ -11,7 +11,7 @@ $external             = InTheNews\get_in_the_news_stories();
 		<?php if ( $in_the_news_more_url ): ?>
 		<tr>
 			<td class="montserratbold" style="padding-top: 40px; padding-bottom: 30px; padding-left: 0; padding-right: 0; font-family: Helvetica, Arial, sans-serif; font-size: 22px; font-weight: bold; color: #006699; text-transform: uppercase; letter-spacing: 1.3px;" align="left">
-				<a href="<?php echo $in_the_news_more_url; ?>" style="text-decoration: none;">UCF In the News</a>
+				<a href="<?php echo Analytics\format_url_news_announcements_utm_params( $in_the_news_more_url ); ?>" style="text-decoration: none;">UCF In the News</a>
 			</td>
 		</tr>
 		<?php endif; ?>


### PR DESCRIPTION
Ensures UTM params are applied to the "In The News" and "Announcements" headings in the News & Announcements email, as well as on individual announcement links and "More Stories" links.

Resolves #64 