### PR TITLE
Gravity Form WYSIWYG toolbar overrides

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -17,6 +17,7 @@ include_once GMUCF_THEME_DIR . 'includes/events-functions.php';
 include_once GMUCF_THEME_DIR . 'includes/in-the-news-functions.php';
 include_once GMUCF_THEME_DIR . 'includes/ucf-today-functions.php';
 include_once GMUCF_THEME_DIR . 'includes/weather-functions.php';
+include_once GMUCF_THEME_DIR . 'includes/request-email-functions.php';
 
 
 // Plugin extras/overrides

--- a/includes/request-email-functions.php
+++ b/includes/request-email-functions.php
@@ -17,7 +17,7 @@ namespace GMUCF\Theme\Includes\RequestEmail;
  *
  * Requires functions defined in the UCF Email Editor plugin.
  *
- * @since TODO
+ * @since 3.0.1
  * @author Jo Dickson
  */
 if ( function_exists( 'email_wysiwyg_toolbar_r1' ) ) {

--- a/includes/request-email-functions.php
+++ b/includes/request-email-functions.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Includes functions related to the Request Email form.
+ */
+namespace GMUCF\Theme\Includes\RequestEmail;
+
+
+/**
+ * Simplifies WYSIWYG editor toolbar buttons in all
+ * Gravity Form WYSIWYG fields on this site.
+ *
+ * NOTE: while there are hooks available for targeting specific
+ * forms' WYSIWYG toolbars, these toolbar settings get cached pretty
+ * aggressively via cookies, and said cookies don't seem to make any
+ * distinction between forms...so, there's not any point in
+ * targeting specific forms/fields with this.
+ *
+ * Requires functions defined in the UCF Email Editor plugin.
+ *
+ * @since TODO
+ * @author Jo Dickson
+ */
+if ( function_exists( 'email_wysiwyg_toolbar_r1' ) ) {
+	add_filter( 'gform_rich_text_editor_buttons', 'email_wysiwyg_toolbar_r1', 10, 0 );
+}
+if ( function_exists( 'email_wysiwyg_toolbar_r2' ) ) {
+	add_filter( 'gform_rich_text_editor_buttons_row_two', 'email_wysiwyg_toolbar_r2', 10, 0 );
+}


### PR DESCRIPTION
Added a couple of filters that update TinyMCE WYSIWYG toolbars on all Gravity Forms to use the button set defined in the UCF Email Editor plugin.  Considering we only have the Request Email form to worry about on the GMUCF site, it's (currently) safe to update the WYSIWYG toolbars for all forms' WYSIWYG fields.

We'll need this if/when we incorporate an initial "email content" field in the Request Email form.