### PR TITLE
Frontend and backend feature lockdown

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -595,7 +595,7 @@ add_action( 'admin_menu', __NAMESPACE__ . '\kill_unused_admin_pages' );
  *
  * http://betterwp.net/wordpress-tips/disable-some-wordpress-pages/
  *
- * @since 1.0.1
+ * @since 3.0.1
  * @author Jo Dickson
  * @return void
  */
@@ -614,7 +614,7 @@ add_action( 'template_redirect', __NAMESPACE__ . '\kill_unused_templates' );
 /**
  * Removes dashboard widgets that reference posts.
  *
- * @since 1.0.1
+ * @since 3.0.1
  * @author Jo Dickson
  * @return void
  */
@@ -634,7 +634,7 @@ add_action( 'wp_dashboard_setup', __NAMESPACE__ . '\kill_unused_dashboard_widget
  * trackbacks, and pingbacks sitewide, and hides references to comments in the
  * WordPress admin to reduce clutter.
  *
- * @since 1.0.1
+ * @since 3.0.1
  * @author Jo Dickson
  * @return void
  */

--- a/includes/config.php
+++ b/includes/config.php
@@ -575,7 +575,7 @@ add_action( 'customize_register', __NAMESPACE__ . '\define_customizer_controls',
 
 
 /**
- * Remove old blogroll Links and Comments admin pages.
+ * Remove unused admin pages from the admin menu.
  *
  * @since 3.0.0
  * @author Jo Dickson
@@ -584,6 +584,134 @@ add_action( 'customize_register', __NAMESPACE__ . '\define_customizer_controls',
 function kill_unused_admin_pages() {
 	remove_menu_page( 'link-manager.php' );
 	remove_menu_page( 'edit-comments.php' );
+	remove_menu_page( 'edit.php' );
 }
 
 add_action( 'admin_menu', __NAMESPACE__ . '\kill_unused_admin_pages' );
+
+
+/**
+ * Kill attachment pages, author pages, archive pages, search, and feeds.
+ *
+ * http://betterwp.net/wordpress-tips/disable-some-wordpress-pages/
+ *
+ * @since 1.0.1
+ * @author Jo Dickson
+ * @return void
+ */
+function kill_unused_templates() {
+	global $wp_query, $post;
+
+	if ( is_author() || is_attachment() || is_archive() || is_search() || is_feed() || is_comment_feed() ) {
+		wp_redirect( home_url() );
+		exit();
+	}
+}
+
+add_action( 'template_redirect', __NAMESPACE__ . '\kill_unused_templates' );
+
+
+/**
+ * Removes dashboard widgets that reference posts.
+ *
+ * @since 1.0.1
+ * @author Jo Dickson
+ * @return void
+ */
+function kill_unused_dashboard_widgets() {
+	global $wp_meta_boxes;
+
+	if ( isset( $wp_meta_boxes['dashboard']['side']['core']['dashboard_quick_press'] ) ) {
+		unset( $wp_meta_boxes['dashboard']['side']['core']['dashboard_quick_press'] );
+	}
+}
+
+add_action( 'wp_dashboard_setup', __NAMESPACE__ . '\kill_unused_dashboard_widgets' );
+
+
+/**
+ * An opinionated set of overrides for this theme that disables comments,
+ * trackbacks, and pingbacks sitewide, and hides references to comments in the
+ * WordPress admin to reduce clutter.
+ *
+ * @since 1.0.1
+ * @author Jo Dickson
+ * @return void
+ */
+function kill_comments() {
+	// Remove the X-Pingback HTTP header, if present.
+	add_filter( 'wp_headers', function( $headers ) {
+		if ( isset( $headers['X-Pingback'] ) ) {
+			unset( $headers['X-Pingback'] );
+		}
+		return $headers;
+	} );
+
+	// Remove native post type support for comments and trackbacks on all
+	// public-facing post types.
+	// NOTE: If an existing post already has comments posted to it, they'll
+	// still be viewable in the Comments metabox when editing the post.
+	$post_types = get_post_types( array( 'public' => true ), 'names' );
+	foreach ( $post_types as $pt ) {
+		if ( post_type_supports( $pt, 'comments' ) ) {
+			remove_post_type_support( $pt, 'comments' );
+		}
+		if ( post_type_supports( $pt, 'trackbacks' ) ) {
+			remove_post_type_support( $pt, 'trackbacks' );
+		}
+	}
+
+	// Disable comments and pingbacks on new posts (these are the primary
+	// default discussion settings under Settings > Discussion)
+	add_filter( 'option_default_pingback_flag', '__return_zero' );
+	add_filter( 'option_default_ping_status', '__return_zero' );
+	add_filter( 'option_default_comment_status', '__return_zero' );
+
+	// Close ability to add new comments and pingbacks on existing posts.
+	add_filter( 'comments_open', '__return_false' );
+	add_filter( 'pings_open', '__return_false' );
+
+	// Remove admin bar link for comments
+	add_action( 'wp_before_admin_bar_render', function() {
+		global $wp_admin_bar;
+		$wp_admin_bar->remove_menu( 'comments' );
+	} );
+
+	// Remove Comments and Settings > Discussion links from the admin menu.
+	// NOTE: Both of these admin views are still accessible if requested
+	// directly.
+	add_action( 'admin_menu', function() {
+		remove_menu_page( 'edit-comments.php' );
+		remove_submenu_page( 'options-general.php', 'options-discussion.php' );
+	} );
+
+	// Remove the recent comments box from the admin dashboard.
+	add_action( 'wp_dashboard_setup', function() {
+		remove_meta_box( 'dashboard_recent_comments', 'dashboard', 'normal' );
+	} );
+
+	// Hide comment count and other inline references to comments in the
+	// admin dashboard and user profile view.
+	$admin_css = '';
+	ob_start();
+?>
+	<style>
+		#dashboard_right_now .comment-count,
+		#dashboard_right_now .comment-mod-count,
+		#latest-comments,
+		#welcome-panel .welcome-comments,
+		.user-comment-shortcuts-wrap {
+			display: none !important;
+		}
+	</style>
+<?php
+	$admin_css = ob_get_clean();
+	add_action( 'admin_print_styles-index.php', function() use ( $admin_css ) {
+		echo $admin_css;
+	} );
+	add_action( 'admin_print_styles-profile.php', function() use ( $admin_css ) {
+		echo $admin_css;
+	} );
+}
+
+add_action( 'init', __NAMESPACE__ . '\kill_comments' );

--- a/readme.markdown
+++ b/readme.markdown
@@ -22,6 +22,7 @@ These plugins are not technically required for this theme to function normally, 
 * [UCF Email Editor Plugin](https://github.com/UCF/UCF-Email-Editor-Plugin) (for custom emails)
 * [UCF Section Plugin](https://github.com/UCF/UCF-Section-Plugin) (for custom emails)
 * [WP Mail SMTP](https://wordpress.org/plugins/wp-mail-smtp/) (for form confirmations and Email CPT instant sends)
+* [Disable REST API](https://wordpress.org/plugins/disable-json-api/), or equivalent plugin (to disable unused REST endpoints)
 
 
 ## Configuration


### PR DESCRIPTION
- Removed post add/edit links from the WP admin menu, as they're not in use on the GMUCF site.  Also removed the "quick draft" dashboard widget to clean things up a little bit
- Added template redirects for unused views (search, archives, etc), similarly to how the UCF WP Theme behaves
- Copied over comment-removing logic from UCF WP Theme
- Added "Disable REST API" or similar plugin as recommended for the GMUCF site to disable the REST API