### PR TITLE
Simplified UTM param insertion in News & Announcements emails

### DIFF
--- a/includes/analytics-functions.php
+++ b/includes/analytics-functions.php
@@ -9,9 +9,6 @@ namespace GMUCF\Theme\Includes\Analytics;
  * Returns the provided URL formatted with UTM
  * parameters for the News & Announcement emails.
  *
- * Respects existing query params in the URL, but replaces
- * existing UTM params if present.
- *
  * @since 3.0.0
  * @author Jo Dickson
  * @param string $url Arbitrary URL linking to external content
@@ -23,25 +20,9 @@ function format_url_news_announcements_utm_params( $url='' ) {
 	$campaign = get_option( 'news_utm_campaign' );
 	$content  = wp_date( 'Y-m-d' );
 
-	$url_base = '';
-	$existing_params = '';
-	$existing_url_split = explode( '?', $url, 1 );
-	if ( is_array( $existing_url_split ) ) {
-		$url_base = $existing_url_split[0];
-		if ( isset( $existing_url_split[1] ) ) {
-			$existing_params = $existing_url_split[1];
-		}
+	if ( function_exists( 'format_url_utm_params' ) ) {
+		$url = format_url_utm_params( $url, $source, $medium, $campaign, $content );
 	}
-
-	parse_str( parse_url( $url, PHP_URL_QUERY ), $params_array );
-	if ( is_array( $params_array ) ) {
-		$params_array['utm_source'] = $source;
-		$params_array['utm_medium'] = $medium;
-		$params_array['utm_campaign'] = $campaign;
-		$params_array['utm_content'] = $content;
-	}
-
-	return $url_base . '?' . http_build_query( $params_array );
 
 	return $url;
 }


### PR DESCRIPTION
**Please review https://github.com/UCF/UCF-Email-Editor-Plugin/pull/35 before reviewing this PR.  Thanks!**

-----

Updated logic for appending UTM params to News & Announcement email links to utilize the Email Editor Plugin's new `format_url_utm_params()` function.  Helps to reduce redundancy, and `format_url_utm_params()` is much more robust.

Depends on https://github.com/UCF/UCF-Email-Editor-Plugin/pull/35