### PR TITLE
Coronavirus emails

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -12,6 +12,7 @@ include_once GMUCF_THEME_DIR . 'includes/template-redirect-functions.php';
 
 include_once GMUCF_THEME_DIR . 'includes/analytics-functions.php';
 include_once GMUCF_THEME_DIR . 'includes/announcements-functions.php';
+include_once GMUCF_THEME_DIR . 'includes/coronavirus-functions.php';
 include_once GMUCF_THEME_DIR . 'includes/email-markup-functions.php';
 include_once GMUCF_THEME_DIR . 'includes/events-functions.php';
 include_once GMUCF_THEME_DIR . 'includes/in-the-news-functions.php';

--- a/includes/config.php
+++ b/includes/config.php
@@ -37,6 +37,7 @@ define( 'GMUCF_THEME_CUSTOMIZER_DEFAULTS', serialize( array(
 	'weather_service_extended_url'     => 'https://weather.smca.ucf.edu/?data=forecastExtended',
 	'weather_service_cache_duration'   => 60 * 15, // seconds
 	'weather_service_timeout'          => 10, // seconds
+	'coronavirus_email_options_url'    => 'https://www.ucf.edu/coronavirus/wp-json/coronavirus-weekly-email/v1/options/',
 	'email_preview_base_list'          => ''
 ) ) );
 
@@ -140,6 +141,13 @@ function define_customizer_sections( $wp_customize ) {
 		'events',
 		array(
 			'title' => 'Events Data'
+		)
+	);
+
+	$wp_customize->add_section(
+		'coronavirus',
+		array(
+			'title' => 'Coronavirus Email Data'
 		)
 	);
 
@@ -450,6 +458,26 @@ function define_customizer_controls( $wp_customize ) {
 			'description' => 'Number of seconds to wait before timing out a request to the Events system feed.',
 			'section'     => 'events',
 			'type'        => 'number'
+		)
+	);
+
+	//
+	// Coronavirus
+	//
+	$wp_customize->add_setting(
+		'coronavirus_email_options_url',
+		array (
+			'type' => 'option',
+			'default' => Utilities\get_option_default( 'coronavirus_email_options_url' )
+		)
+	);
+	$wp_customize->add_control(
+		'coronavirus_email_options_url',
+		array(
+			'label'       => 'Coronavirus Email Options Data URL',
+			'description' => 'URL to the Coronavirus email options feed.',
+			'section'     => 'coronavirus',
+			'type'        => 'text'
 		)
 	);
 

--- a/includes/coronavirus-functions.php
+++ b/includes/coronavirus-functions.php
@@ -31,22 +31,6 @@ function fetch_options_data() {
 
 
 /**
- * Returns the email title defined in the
- * Coronavirus email options feed.
- *
- * @since 3.1.0
- * @author Jo Dickson
- * @return string|false
- */
-function get_email_title() {
-	$options = fetch_options_data();
-	if ( ! $options || ! isset( $options->email_content ) ) return false;
-
-	return escape_chars( $options->title );
-}
-
-
-/**
  * Returns all email content data from the
  * Coronavirus email options feed.
  *

--- a/includes/coronavirus-functions.php
+++ b/includes/coronavirus-functions.php
@@ -130,21 +130,49 @@ function get_current_row() {
 
 
 /**
- * Format WYSIWYG-generated content for use in
+ * Format WYSIWYG-generated paragraph content for use in
  * Coronavirus email HTML.
  *
  * Utilizes functions defined in the UCF Email Editor plugin.
+ *
+ * TODO update this function to strip all HTML tags except
+ * for those supported by the "Email Content" WYSIWYG toolbar
+ * in the CV Utilities plugin
  *
  * @since 3.1.0
  * @author Jo Dickson
  * @param string $content Arbitrary HTML string
  * @return string Formatted content
  */
-function format_wysiwyg_content( $content ) {
+function format_paragraph_content( $content ) {
 	$content = \convert_p_tags( $content );
 	$content = \convert_list_tags( $content, 'ul' );
 	$content = \convert_list_tags( $content, 'ol' );
 	$content = \convert_li_tags( $content );
+	$content = escape_chars( $content );
+
+	return $content;
+}
+
+
+/**
+ * Formats WYSIWYG-generated deck content for use
+ * in Coronavirus email HTML.
+ *
+ * TODO update this function to strip literally all
+ * HTML except for <strong>/<em>
+ *
+ * @since 3.1.0
+ * @author Jo Dickson
+ * @param string $content Arbitrary HTML string
+ * @return string Formatted content
+ */
+function format_deck_content( $content ) {
+	// Strip <p> tags entirely (no replacement, since decks may
+	// be wrapped within a link)
+	$content = preg_replace( '/<p[^>]*>/', '', $content );
+	$content = preg_replace( '/<\/p>/', '', $content );
+
 	$content = escape_chars( $content );
 
 	return $content;

--- a/includes/coronavirus-functions.php
+++ b/includes/coronavirus-functions.php
@@ -13,6 +13,7 @@ use GMUCF\Theme\Includes\Utilities;
  *
  * @since 3.1.0
  * @author Jo Dickson
+ * @return object|false
  */
 function fetch_options_data() {
 	$feed_url = get_option( 'coronavirus_email_options_url' );
@@ -26,4 +27,71 @@ function fetch_options_data() {
 	}
 
 	return $json;
+}
+
+
+/**
+ * Returns all email content data from the
+ * Coronavirus email options feed.
+ *
+ * @since 3.1.0
+ * @author Jo Dickson
+ * @return object
+ */
+function get_email_content() {
+	$options = fetch_options_data();
+	if ( ! $options || ! isset( $options->email_content ) ) return false;
+
+	return $options->email_content;
+}
+
+
+/**
+ * Returns a template part for the provided
+ * row of email content.
+ *
+ * @since 3.1.0
+ * @author Jo Dickson
+ * @param object $row Row of email content data
+ * @return void
+ */
+function display_component( $row ) {
+	$component = $row->acf_fc_layout ?? '';
+	if ( ! $component ) return;
+
+	// Pass along $row data to the template part:
+	set_query_var( 'gmucf_coronavirus_current_row', $row );
+
+	get_template_part( "template-parts/coronavirus/components/$component" );
+
+	// Clean up afterwards:
+	set_query_var( 'gmucf_coronavirus_current_row', false );
+}
+
+
+/**
+ * Returns data for the current row being looped through.
+ * For use in component template parts.
+ *
+ * @since 3.1.0
+ * @author Jo Dickson
+ * @return object
+ */
+function get_current_row() {
+	return get_query_var( 'gmucf_coronavirus_current_row' );
+}
+
+
+/**
+ * TODO
+ * Format WYSIWYG-generated content for use in
+ * Coronavirus email HTML
+ *
+ * @since 3.1.0
+ * @author Jo Dickson
+ * @param string $content Arbitrary HTML string
+ * @return string Formatted content
+ */
+function format_wysiwyg_content( $content ) {
+	return $content;
 }

--- a/includes/coronavirus-functions.php
+++ b/includes/coronavirus-functions.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Functions related to feed retrieval and display
+ * of Coronavirus email content
+ */
+namespace GMUCF\Theme\Includes\Coronavirus;
+use GMUCF\Theme\Includes\Utilities;
+
+
+/**
+ * Fetches Coronavirus email options from the
+ * Coronavirus website.
+ *
+ * @since 3.1.0
+ * @author Jo Dickson
+ */
+function fetch_options_data() {
+	$feed_url = get_option( 'coronavirus_email_options_url' );
+	if ( ! $feed_url ) {
+		error_log( 'GMUCF - Could not retrieve options data for Coronavirus email - no feed URL set' );
+	}
+
+	$json = Utilities\fetch_json( $feed_url );
+	if ( ! $json ) {
+		error_log( 'GMUCF - Could not retrieve options data for Coronavirus email' );
+	}
+
+	return $json;
+}

--- a/includes/coronavirus-functions.php
+++ b/includes/coronavirus-functions.php
@@ -119,10 +119,6 @@ function get_current_row() {
  *
  * Utilizes functions defined in the UCF Email Editor plugin.
  *
- * TODO update this function to strip all HTML tags except
- * for those supported by the "Email Content" WYSIWYG toolbar
- * in the CV Utilities plugin
- *
  * @since 3.1.0
  * @author Jo Dickson
  * @param string $content Arbitrary HTML string
@@ -142,9 +138,6 @@ function format_paragraph_content( $content ) {
 /**
  * Formats WYSIWYG-generated deck content for use
  * in Coronavirus email HTML.
- *
- * TODO update this function to strip literally all
- * HTML except for <strong>/<em>
  *
  * @since 3.1.0
  * @author Jo Dickson

--- a/includes/template-redirect-functions.php
+++ b/includes/template-redirect-functions.php
@@ -49,6 +49,8 @@ function gmucf_template_redirect() {
 			'events/weekend/mail/' => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/mail/base' ); },
 			'events/weekend/text/' => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/text/base' ); },
 			'events/weekend/'      => function() { $_GET['edition'] = 'weekend'; display_gmucf_template( 'template-parts/events/browser/base' ); },
+			'coronavirus/mail/'    => function() { display_gmucf_template( 'template-parts/coronavirus/mail/base' ); },
+			'coronavirus/'         => function() { display_gmucf_template( 'template-parts/coronavirus/browser/base' ); },
 		);
 
 		foreach ( $mapping as $path => $func ) {

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -203,7 +203,7 @@ function remove_quotes( $s ) {
  * @return mixed JSON-decoded object or false on failure
  */
 function fetch_json( $url ) {
-	$response      = wp_remote_get( $url, array( 'timeout' => 15 ) );
+	$response      = wp_remote_get( $url . '?' . time(), array( 'timeout' => 15 ) );
 	$response_code = wp_remote_retrieve_response_code( $response );
 	$result        = false;
 

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -191,3 +191,25 @@ function sanitize_for_email( $s ) {
 function remove_quotes( $s ) {
 	return str_replace( '"', '', $s );
 }
+
+
+/**
+ * Returns a JSON object from the provided URL.  Detects undesirable status
+ * codes and returns false if the response doesn't look valid.
+ *
+ * @since 3.1.0
+ * @author Jo Dickson
+ * @param string $url URL that points to a JSON object/feed
+ * @return mixed JSON-decoded object or false on failure
+ */
+function fetch_json( $url ) {
+	$response      = wp_remote_get( $url, array( 'timeout' => 15 ) );
+	$response_code = wp_remote_retrieve_response_code( $response );
+	$result        = false;
+
+	if ( is_array( $response ) && is_int( $response_code ) && $response_code < 400 ) {
+		$result = json_decode( wp_remote_retrieve_body( $response ) );
+	}
+
+	return $result;
+}

--- a/template-parts/coronavirus/browser/base.php
+++ b/template-parts/coronavirus/browser/base.php
@@ -1,0 +1,9 @@
+<?php
+namespace GMUCF\Theme\TemplateParts\Coronavirus\Browser\Base;
+use GMUCF\Theme\Includes\Coronavirus;
+
+
+echo get_template_part( 'template-parts/coronavirus/browser/header' );
+echo get_template_part( 'template-parts/coronavirus/browser/body' );
+echo get_template_part( 'template-parts/coronavirus/browser/footer' );
+?>

--- a/template-parts/coronavirus/browser/body.php
+++ b/template-parts/coronavirus/browser/body.php
@@ -1,1 +1,12 @@
-TODO body
+<?php
+namespace GMUCF\Theme\TemplateParts\Coronavirus\Browser\Body;
+use GMUCF\Theme\Includes\Coronavirus;
+
+
+$content = Coronavirus\get_email_content();
+if ( $content ) {
+	foreach ( $content as $row ) {
+		echo Coronavirus\display_component( $row );
+	}
+}
+?>

--- a/template-parts/coronavirus/browser/body.php
+++ b/template-parts/coronavirus/browser/body.php
@@ -1,0 +1,1 @@
+TODO body

--- a/template-parts/coronavirus/browser/body.php
+++ b/template-parts/coronavirus/browser/body.php
@@ -6,7 +6,7 @@ use GMUCF\Theme\Includes\Coronavirus;
 $content = Coronavirus\get_email_content();
 if ( $content ) {
 	foreach ( $content as $row ) {
-		echo Coronavirus\display_component( $row );
+		echo Coronavirus\display_row( $row );
 	}
 }
 ?>

--- a/template-parts/coronavirus/browser/footer.php
+++ b/template-parts/coronavirus/browser/footer.php
@@ -1,0 +1,5 @@
+<?php
+namespace GMUCF\Theme\TemplateParts\Coronavirus\Browser\Footer;
+use GMUCF\Theme\Includes\Coronavirus;
+?>
+TODO browser footer

--- a/template-parts/coronavirus/browser/footer.php
+++ b/template-parts/coronavirus/browser/footer.php
@@ -2,4 +2,87 @@
 namespace GMUCF\Theme\TemplateParts\Coronavirus\Browser\Footer;
 use GMUCF\Theme\Includes\Coronavirus;
 ?>
-TODO browser footer
+							<tr>
+								<td style="text-align: left;" align="left">
+									<table class="container-inner" style="text-align: center; margin: auto; min-width: 580px; width: 580px;" width="580" align="center">
+										<tbody>
+											<tr>
+												<td style="text-align: left; border-bottom-style: solid; height: 0; line-height: 0; max-height: 0; min-height: 0; overflow: hidden; padding: 0; width: 100%; border-bottom-width: 3px; border-color: #fc0;" width="100%" align="left"></td>
+											</tr>
+											<tr>
+												<td style="padding-bottom: 30px; padding-top: 45px; text-align: center;" align="center">
+													<table style="text-align: center; width: auto;" align="center">
+														<tbody>
+															<tr>
+																<td style="text-align: left; padding-right: 10px;" align="left">
+																	<a href="https://www.facebook.com/ucf/">
+																		<img style="width: 42px;" width="42" src="<?php echo GMUCF_THEME_IMG_URL; ?>/social/facebook-circle.png" alt="Facebook">
+																	</a>
+																</td>
+																<td style="text-align: left; padding-right: 10px;" align="left">
+																	<a href="https://www.twitter.com/UCF/">
+																		<img style="width: 42px;" width="42" src="<?php echo GMUCF_THEME_IMG_URL; ?>/social/twitter-circle.png" alt="Twitter">
+																	</a>
+																</td>
+																<td style="text-align: left; padding-right: 10px;" align="left">
+																	<a href="https://www.instagram.com/ucf.edu">
+																		<img style="width: 42px;" width="42" src="<?php echo GMUCF_THEME_IMG_URL; ?>/social/instagram-circle.png" alt="Instagram">
+																	</a>
+																</td>
+																<td style="text-align: left; padding-right: 10px;" align="left">
+																	<a href="https://www.linkedin.com/edu/university-of-central-florida-18118">
+																		<img style="width: 42px;" width="42" src="<?php echo GMUCF_THEME_IMG_URL; ?>/social/linkedin-circle.png" alt="LinkedIn">
+																	</a>
+																</td>
+																<td style="text-align: left;" align="left">
+																	<a href="https://www.youtube.com/user/UCF/">
+																		<img style="width: 42px;" width="42" src="<?php echo GMUCF_THEME_IMG_URL; ?>/social/youtube-circle.png" alt="YouTube">
+																	</a>
+																</td>
+															</tr>
+														</tbody>
+													</table>
+												</td>
+											</tr>
+											<tr>
+												<td style="padding-bottom: 15px; text-align: center;" align="center">
+													<a href="https://www.ucf.edu/">
+														<img src="<?php echo GMUCF_THEME_IMG_URL; ?>/ucf-tab.png" style="width: 100px;" width="100" alt="UCF">
+													</a>
+												</td>
+											</tr>
+											<tr>
+												<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; text-align: center; font-size: 13px; font-weight: 700; text-transform: uppercase;" align="center">
+													<a style="color: #000; text-decoration: none; letter-spacing: 1.25px;" href="https://www.ucf.edu/">
+														University of Central Florida
+													</a>
+												</td>
+											</tr>
+											<tr>
+												<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; text-align: center; font-size: 13px;" align="center">
+													4000 Central Florida Blvd.
+												</td>
+											</tr>
+											<tr>
+												<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; text-align: center; font-size: 13px;" align="center">
+													Orlando, FL 32816
+												</td>
+											</tr>
+											<tr>
+												<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; text-align: center; font-size: 13px; padding-bottom: 45px;" align="center">
+													407-823-2000
+												</td>
+											</tr>
+										</tbody>
+									</table>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+ 				</td>
+			</tr>
+		</tbody>
+	</table>
+
+</body>
+</html>

--- a/template-parts/coronavirus/browser/header.php
+++ b/template-parts/coronavirus/browser/header.php
@@ -4,5 +4,198 @@ use GMUCF\Theme\Includes\Coronavirus;
 
 
 $current_date = current_datetime();
+$title        = Coronavirus\get_email_title();
 ?>
-TODO header
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en">
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<meta name="format-detection" content="telephone=no">
+	<meta name="viewport" content="initial-scale=1">
+
+    <style type="text/css">
+.ReadMsgBody {
+  background-color: #fff;
+  width: 100%;
+}
+
+.ExternalClass {
+  background-color: #fff;
+  width: 100%;
+}
+
+.ExternalClass p,
+.ExternalClass span,
+.ExternalClass font,
+.ExternalClass td,
+.ExternalClass div {
+  line-height: 100%;
+}
+
+* {
+  zoom: 1;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  -webkit-text-size-adjust: none;
+  -ms-text-size-adjust: none;
+}
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
+}
+
+th {
+  font-weight: normal;
+}
+
+a {
+  color: #0262b6;
+}
+
+img {
+  border: 0;
+  border-style: none;
+}
+	</style>
+
+	<style type="text/css">
+@font-face {
+  font-family: "UCF-Sans-Serif-Alt";
+  font-style: normal;
+  font-weight: 400;
+  src: url("https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/ucfsansserifalt-medium-webfont.woff2") format("woff2"), url("https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/ucfsansserifalt-medium-webfont.woff") format("woff");
+  mso-font-alt: 'Arial';}
+@font-face {
+  font-family: "UCF-Sans-Serif-Alt";
+  font-style: normal;
+  font-weight: 700;
+  src: url("https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/ucfsansserifalt-bold-webfont.woff2") format("woff2"), url("https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/ucfsansserifalt-bold-webfont.woff") format("woff");
+  mso-font-alt: 'Arial';}
+@media (max-width: 640px) {
+  .img-fluid {
+    max-width: none !important;
+    width: 100% !important;
+  }
+
+  .hide-mobile {
+    display: none;
+    font-size: 0;
+    height: 0;
+    line-height: 0;
+    max-height: 0;
+    max-width: 0;
+    mso-hide: all;
+    overflow: hidden;
+    width: 0;
+  }
+
+  .show-mobile {
+    display: block !important;
+    font-size: initial !important;
+    height: auto !important;
+    line-height: initial;
+    max-height: none !important;
+    max-width: none !important;
+    mso-hide: none !important;
+    overflow: visible !important;
+    width: auto !important;
+  }
+
+  .container-outer {
+    margin: 0 !important;
+    min-width: 0 !important;
+    width: 100% !important;
+  }
+
+  .container-inner {
+    border-left: 0 solid transparent !important;
+    border-right: 0 solid transparent !important;
+  }
+
+  .container-inner {
+    margin: 0 !important;
+    min-width: 0 !important;
+    padding-left: 15px;
+    padding-right: 15px;
+    width: 100% !important;
+  }
+
+  .mobile-column-collapse {
+    border-left: 0 solid transparent !important;
+    border-right: 0 solid transparent !important;
+  }
+
+  .mobile-column-collapse {
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+  }
+
+  .mobile-column-collapse {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  .mobile-column-collapse {
+    clear: both;
+    display: block !important;
+    float: left;
+    overflow: hidden;
+    width: 100% !important;
+  }
+
+  .w-50-desktop {
+    width: 100% !important;
+  }
+
+  .w-75-desktop {
+    width: 100% !important;
+  }
+
+  table {
+    border-collapse: separate !important;
+  }
+}
+	</style>
+
+	<title><?php echo $title; ?></title>
+</head>
+<body>
+
+	<table style="text-align: center; background-color: #eee; min-width: 100%; table-layout: fixed; width: 100%;" width="100%" bgcolor="#eee" align="center">
+		<tbody>
+			<tr>
+				<td style="text-align: left;" align="left">
+					<table class="container-outer" style="text-align: center; background-color: #fff; margin: auto; min-width: 640px; width: 640px;" width="640" bgcolor="#fff" align="center">
+						<tbody>
+							<tr>
+								<td style="text-align: left;" align="left">
+									<img class="img-fluid" src="https://s3.amazonaws.com/web.ucf.edu/email/2020-cv-newsletter-demos/dummy-header.jpg" alt="TODO" style="max-width: 100%;">
+								</td>
+							</tr>
+							<tr>
+								<td style="text-align: left;" align="left">
+									<table class="container-inner" style="text-align: center; margin: auto; min-width: 580px; width: 580px;" width="580" align="center">
+										<tbody>
+											<tr>
+												<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; text-align: left; padding-bottom: 5px; padding-top: 30px; font-size: 13px; font-weight: 700; color: #767676; text-transform: uppercase;" align="left">
+													<?php echo $current_date->format( 'M d, Y' ); ?>
+												</td>
+											</tr>
+											<tr>
+												<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; text-align: left; padding-bottom: 15px; font-size: 27px; letter-spacing: -0.025em; line-height: 1.3;" align="left">
+													<?php echo $title; ?>
+												</td>
+											</tr>
+										</tbody>
+									</table>
+								</td>
+							</tr>

--- a/template-parts/coronavirus/browser/header.php
+++ b/template-parts/coronavirus/browser/header.php
@@ -3,8 +3,11 @@ namespace GMUCF\Theme\TemplateParts\Coronavirus\Browser\Header;
 use GMUCF\Theme\Includes\Coronavirus;
 
 
-$current_date = current_datetime();
-$title        = Coronavirus\get_email_title();
+$current_date   = current_datetime();
+$options        = Coronavirus\fetch_options_data();
+$title          = isset( $options->title ) ? Coronavirus\escape_chars( $options->title ) : '';
+$header_img     = $options->header_image ?? null;
+$header_img_url = $options->header_image_link ?? null;
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html lang="en">
@@ -176,11 +179,19 @@ img {
 				<td style="text-align: left;" align="left">
 					<table class="container-outer" style="text-align: center; background-color: #fff; margin: auto; min-width: 640px; width: 640px;" width="640" bgcolor="#fff" align="center">
 						<tbody>
+							<?php if ( $header_img ): ?>
 							<tr>
 								<td style="text-align: left;" align="left">
-									<img class="img-fluid" src="https://s3.amazonaws.com/web.ucf.edu/email/2020-cv-newsletter-demos/dummy-header.jpg" alt="TODO" style="max-width: 100%;">
+									<?php if ( $header_img_url ): ?>
+									<a href="<?php echo $header_img_url; ?>">
+									<?php endif; ?>
+										<img class="img-fluid" src="<?php echo $header_img; ?>" alt="UCF Coronavirus Information" style="max-width: 100%;">
+									<?php if ( $header_img_url ): ?>
+									</a>
+									<?php endif; ?>
 								</td>
 							</tr>
+							<?php endif; ?>
 							<tr>
 								<td style="text-align: left;" align="left">
 									<table class="container-inner" style="text-align: center; margin: auto; min-width: 580px; width: 580px;" width="580" align="center">

--- a/template-parts/coronavirus/browser/header.php
+++ b/template-parts/coronavirus/browser/header.php
@@ -186,12 +186,12 @@ img {
 									<table class="container-inner" style="text-align: center; margin: auto; min-width: 580px; width: 580px;" width="580" align="center">
 										<tbody>
 											<tr>
-												<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; text-align: left; padding-bottom: 5px; padding-top: 30px; font-size: 13px; font-weight: 700; color: #767676; text-transform: uppercase;" align="left">
+												<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; text-align: left; padding-bottom: 10px; padding-top: 30px; font-size: 13px; font-weight: 700; color: #767676; text-transform: uppercase;" align="left">
 													<?php echo $current_date->format( 'M d, Y' ); ?>
 												</td>
 											</tr>
 											<tr>
-												<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; text-align: left; padding-bottom: 15px; font-size: 27px; letter-spacing: -0.025em; line-height: 1.3;" align="left">
+												<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; text-align: left; padding-bottom: 25px; font-size: 27px; letter-spacing: -0.025em; line-height: 1.3;" align="left">
 													<?php echo $title; ?>
 												</td>
 											</tr>

--- a/template-parts/coronavirus/browser/header.php
+++ b/template-parts/coronavirus/browser/header.php
@@ -1,0 +1,8 @@
+<?php
+namespace GMUCF\Theme\TemplateParts\Coronavirus\Browser\Header;
+use GMUCF\Theme\Includes\Coronavirus;
+
+
+$current_date = current_datetime();
+?>
+TODO header

--- a/template-parts/coronavirus/components/article.php
+++ b/template-parts/coronavirus/components/article.php
@@ -1,0 +1,8 @@
+<?php
+namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\Article;
+use GMUCF\Theme\Includes\Coronavirus;
+
+
+$row = Coronavirus\get_current_row();
+?>
+TODO article row markup

--- a/template-parts/coronavirus/components/article.php
+++ b/template-parts/coronavirus/components/article.php
@@ -6,7 +6,7 @@ use GMUCF\Theme\Includes\Coronavirus;
 $row = Coronavirus\get_current_row();
 $thumbnail = $row->thumbnail;
 $title     = Coronavirus\escape_chars( $row->article_title );
-$deck      = Coronavirus\format_wysiwyg_content( $row->article_deck );
+$deck      = Coronavirus\format_deck_content( $row->article_deck );
 $href      = $row->links_to;
 ?>
 <tr>

--- a/template-parts/coronavirus/components/article.php
+++ b/template-parts/coronavirus/components/article.php
@@ -10,7 +10,7 @@ $deck      = Coronavirus\format_deck_content( $row->article_deck );
 $href      = $row->links_to;
 ?>
 <tr>
-	<td style="text-align: left; padding-bottom: 30px;" align="left">
+	<td style="text-align: left; padding-bottom: 40px;" align="left">
 		<table style="text-align: center; width: 100%;" width="100%" align="center">
 			<tbody>
 				<?php if ( $thumbnail ): ?>
@@ -28,7 +28,7 @@ $href      = $row->links_to;
 				<?php endif; ?>
 				<?php if ( $title ): ?>
 				<tr>
-					<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; text-align: left; padding-top: 5px; padding-bottom: 10px; font-size: 24px; font-weight: bold; line-height: 1.2;" align="left">
+					<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; text-align: left; padding-bottom: 10px; font-size: 24px; font-weight: bold; line-height: 1.2;" align="left">
 						<?php if ( $href ): ?>
 						<a href="<?php echo $href; ?>" style="color: #000; text-decoration: none;">
 						<?php endif; ?>

--- a/template-parts/coronavirus/components/article_list.php
+++ b/template-parts/coronavirus/components/article_list.php
@@ -1,0 +1,8 @@
+<?php
+namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\ArticleList;
+use GMUCF\Theme\Includes\Coronavirus;
+
+
+$row = Coronavirus\get_current_row();
+?>
+TODO article list markup

--- a/template-parts/coronavirus/components/article_list.php
+++ b/template-parts/coronavirus/components/article_list.php
@@ -8,7 +8,7 @@ $row = Coronavirus\get_current_row();
 foreach ( $row->articles as $key => $article ):
 	$thumbnail = $article->thumbnail;
 	$title     = Coronavirus\escape_chars( $article->article_title );
-	$deck      = Coronavirus\format_wysiwyg_content( $article->article_deck );
+	$deck      = Coronavirus\format_deck_content( $article->article_deck );
 	$href      = $article->links_to;
 ?>
 <tr>

--- a/template-parts/coronavirus/components/article_list.php
+++ b/template-parts/coronavirus/components/article_list.php
@@ -4,64 +4,73 @@ use GMUCF\Theme\Includes\Coronavirus;
 
 
 $row = Coronavirus\get_current_row();
-
-foreach ( $row->articles as $key => $article ):
-	$thumbnail = $article->thumbnail;
-	$title     = Coronavirus\escape_chars( $article->article_title );
-	$deck      = Coronavirus\format_deck_content( $article->article_deck );
-	$href      = $article->links_to;
 ?>
 <tr>
-	<td style="text-align: left; padding-bottom: 30px;" align="left">
+	<td style="text-align: left; padding-bottom: 10px;" align="left">
 		<table style="text-align: center; width: 100%;" width="100%" align="center">
 			<tbody>
+				<?php
+				foreach ( $row->articles as $key => $article ):
+					$thumbnail = $article->thumbnail;
+					$title     = Coronavirus\escape_chars( $article->article_title );
+					$deck      = Coronavirus\format_deck_content( $article->article_deck );
+					$href      = $article->links_to;
+				?>
 				<tr>
-					<?php if ( $thumbnail ): ?>
-					<td style="text-align: left; padding-right: 20px; vertical-align: top; width: 50px;" width="50" valign="top" align="left">
-						<?php if ( $href ): ?>
-						<a href="<?php echo $href; ?>">
-						<?php endif; ?>
-							<img width="50" src="<?php echo $thumbnail; ?>" alt="">
-						<?php if ( $href ): ?>
-						</a>
-						<?php endif; ?>
-					</td>
-					<?php endif; ?>
-					<td style="text-align: left; vertical-align: top;" valign="top" align="left">
+					<td style="text-align: left; padding-bottom: 30px;" align="left">
 						<table style="text-align: center; width: 100%;" width="100%" align="center">
 							<tbody>
-								<?php if ( $title ): ?>
 								<tr>
-									<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 18px; font-weight: bold; line-height: 1.2; text-align: left; padding-bottom: 10px;" align="left">
+									<?php if ( $thumbnail ): ?>
+									<td style="text-align: left; padding-right: 20px; vertical-align: top; width: 50px;" width="50" valign="top" align="left">
 										<?php if ( $href ): ?>
-										<a href="<?php echo $href; ?>" style="color: #000; text-decoration: none;">
+										<a href="<?php echo $href; ?>">
 										<?php endif; ?>
-											<?php echo $title; ?>
+											<img width="50" src="<?php echo $thumbnail; ?>" alt="">
 										<?php if ( $href ): ?>
 										</a>
 										<?php endif; ?>
 									</td>
-								</tr>
-								<?php endif; ?>
-								<?php if ( $deck ): ?>
-								<tr>
-									<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; text-align: left; font-size: 13px;" align="left">
-										<?php if ( $href ): ?>
-										<a href="<?php echo $href; ?>" style="color: #000; text-decoration: none;">
-										<?php endif; ?>
-											<?php echo $deck; ?>
-										<?php if ( $href ): ?>
-										</a>
-										<?php endif; ?>
+									<?php endif; ?>
+									<td style="text-align: left; vertical-align: top;" valign="top" align="left">
+										<table style="text-align: center; width: 100%;" width="100%" align="center">
+											<tbody>
+												<?php if ( $title ): ?>
+												<tr>
+													<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 18px; font-weight: bold; line-height: 1.2; text-align: left; padding-bottom: 10px;" align="left">
+														<?php if ( $href ): ?>
+														<a href="<?php echo $href; ?>" style="color: #000; text-decoration: none;">
+														<?php endif; ?>
+															<?php echo $title; ?>
+														<?php if ( $href ): ?>
+														</a>
+														<?php endif; ?>
+													</td>
+												</tr>
+												<?php endif; ?>
+												<?php if ( $deck ): ?>
+												<tr>
+													<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; text-align: left; font-size: 13px;" align="left">
+														<?php if ( $href ): ?>
+														<a href="<?php echo $href; ?>" style="color: #000; text-decoration: none;">
+														<?php endif; ?>
+															<?php echo $deck; ?>
+														<?php if ( $href ): ?>
+														</a>
+														<?php endif; ?>
+													</td>
+												</tr>
+												<?php endif; ?>
+											</tbody>
+										</table>
 									</td>
 								</tr>
-								<?php endif; ?>
 							</tbody>
 						</table>
 					</td>
 				</tr>
+				<?php endforeach; ?>
 			</tbody>
 		</table>
 	</td>
 </tr>
-<?php endforeach; ?>

--- a/template-parts/coronavirus/components/article_list.php
+++ b/template-parts/coronavirus/components/article_list.php
@@ -4,5 +4,64 @@ use GMUCF\Theme\Includes\Coronavirus;
 
 
 $row = Coronavirus\get_current_row();
+
+foreach ( $row->articles as $key => $article ):
+	$thumbnail = $article->thumbnail;
+	$title     = Coronavirus\escape_chars( $article->article_title );
+	$deck      = Coronavirus\format_wysiwyg_content( $article->article_deck );
+	$href      = $article->links_to;
 ?>
-TODO article list markup
+<tr>
+	<td style="text-align: left; padding-bottom: 30px;" align="left">
+		<table style="text-align: center; width: 100%;" width="100%" align="center">
+			<tbody>
+				<tr>
+					<?php if ( $thumbnail ): ?>
+					<td style="text-align: left; padding-right: 20px; vertical-align: top; width: 50px;" width="50" valign="top" align="left">
+						<?php if ( $href ): ?>
+						<a href="<?php echo $href; ?>">
+						<?php endif; ?>
+							<img width="50" src="<?php echo $thumbnail; ?>" alt="">
+						<?php if ( $href ): ?>
+						</a>
+						<?php endif; ?>
+					</td>
+					<?php endif; ?>
+					<td style="text-align: left; vertical-align: top;" valign="top" align="left">
+						<table style="text-align: center; width: 100%;" width="100%" align="center">
+							<tbody>
+								<?php if ( $title ): ?>
+								<tr>
+									<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 18px; font-weight: bold; line-height: 1.2; text-align: left; padding-bottom: 10px;" align="left">
+										<?php if ( $href ): ?>
+										<a href="<?php echo $href; ?>" style="color: #000; text-decoration: none;">
+										<?php endif; ?>
+											<?php echo $title; ?>
+										<?php if ( $href ): ?>
+										</a>
+										<?php endif; ?>
+									</td>
+								</tr>
+								<?php endif; ?>
+								<?php if ( $deck ): ?>
+								<tr>
+									<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; text-align: left; font-size: 13px;" align="left">
+										<?php if ( $href ): ?>
+										<a href="<?php echo $href; ?>" style="color: #000; text-decoration: none;">
+										<?php endif; ?>
+											<?php echo $deck; ?>
+										<?php if ( $href ): ?>
+										</a>
+										<?php endif; ?>
+									</td>
+								</tr>
+								<?php endif; ?>
+							</tbody>
+						</table>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</td>
+</tr>
+<?php endforeach; ?>

--- a/template-parts/coronavirus/components/article_sm.php
+++ b/template-parts/coronavirus/components/article_sm.php
@@ -10,7 +10,7 @@ $deck      = Coronavirus\format_deck_content( $row->article_deck );
 $href      = $row->links_to;
 ?>
 <tr>
-	<td style="text-align: left; padding-bottom: 30px;" align="left">
+	<td style="text-align: left; padding-bottom: 40px;" align="left">
 		<table style="text-align: center; width: 100%;" width="100%" align="center">
 			<tbody>
 				<?php if ( $thumbnail ): ?>
@@ -28,7 +28,7 @@ $href      = $row->links_to;
 				<?php endif; ?>
 				<?php if ( $title ): ?>
 				<tr>
-					<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; text-align: left; padding-top: 5px; padding-bottom: 10px; font-size: 18px; font-weight: bold; line-height: 1.2;" align="left">
+					<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; text-align: left; padding-bottom: 10px; font-size: 18px; font-weight: bold; line-height: 1.2;" align="left">
 						<?php if ( $href ): ?>
 						<a href="<?php echo $href; ?>" style="color: #000; text-decoration: none;">
 						<?php endif; ?>

--- a/template-parts/coronavirus/components/article_sm.php
+++ b/template-parts/coronavirus/components/article_sm.php
@@ -6,7 +6,7 @@ use GMUCF\Theme\Includes\Coronavirus;
 $row       = Coronavirus\get_current_row();
 $thumbnail = $row->thumbnail;
 $title     = Coronavirus\escape_chars( $row->article_title );
-$deck      = Coronavirus\format_wysiwyg_content( $row->article_deck );
+$deck      = Coronavirus\format_deck_content( $row->article_deck );
 $href      = $row->links_to;
 ?>
 <tr>

--- a/template-parts/coronavirus/components/article_sm.php
+++ b/template-parts/coronavirus/components/article_sm.php
@@ -41,7 +41,7 @@ $href      = $row->links_to;
 				<?php endif; ?>
 				<?php if ( $deck ): ?>
 				<tr>
-					<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; text-align: left; padding-bottom: 45px; font-size: 13px;" align="left">
+					<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; text-align: left; padding-bottom: 0px; font-size: 13px;" align="left">
 						<?php if ( $href ): ?>
 						<a href="<?php echo $href; ?>" style="color: #000; text-decoration: none;">
 						<?php endif; ?>

--- a/template-parts/coronavirus/components/article_sm.php
+++ b/template-parts/coronavirus/components/article_sm.php
@@ -3,7 +3,7 @@ namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\Article;
 use GMUCF\Theme\Includes\Coronavirus;
 
 
-$row = Coronavirus\get_current_row();
+$row       = Coronavirus\get_current_row();
 $thumbnail = $row->thumbnail;
 $title     = Coronavirus\escape_chars( $row->article_title );
 $deck      = Coronavirus\format_wysiwyg_content( $row->article_deck );
@@ -15,11 +15,11 @@ $href      = $row->links_to;
 			<tbody>
 				<?php if ( $thumbnail ): ?>
 				<tr>
-					<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.5; text-align: left; padding-bottom: 15px;" align="left">
+					<td style="text-align: left; padding-bottom: 15px;" align="left">
 						<?php if ( $href ): ?>
 						<a href="<?php echo $href; ?>">
 						<?php endif; ?>
-							<img class="img-fluid" width="580" src="<?php echo $thumbnail; ?>" alt="" style="max-width: 100%;">
+							<img class="img-fluid" width="275" src="<?php echo $thumbnail; ?>" alt="" style="max-width: 100%;">
 						<?php if ( $href ): ?>
 						</a>
 						<?php endif; ?>
@@ -28,7 +28,7 @@ $href      = $row->links_to;
 				<?php endif; ?>
 				<?php if ( $title ): ?>
 				<tr>
-					<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; text-align: left; padding-top: 5px; padding-bottom: 10px; font-size: 24px; font-weight: bold; line-height: 1.2;" align="left">
+					<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; text-align: left; padding-top: 5px; padding-bottom: 10px; font-size: 18px; font-weight: bold; line-height: 1.2;" align="left">
 						<?php if ( $href ): ?>
 						<a href="<?php echo $href; ?>" style="color: #000; text-decoration: none;">
 						<?php endif; ?>
@@ -41,7 +41,7 @@ $href      = $row->links_to;
 				<?php endif; ?>
 				<?php if ( $deck ): ?>
 				<tr>
-					<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.5; text-align: left;" align="left">
+					<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; text-align: left; padding-bottom: 45px; font-size: 13px;" align="left">
 						<?php if ( $href ): ?>
 						<a href="<?php echo $href; ?>" style="color: #000; text-decoration: none;">
 						<?php endif; ?>

--- a/template-parts/coronavirus/components/custom_html.php
+++ b/template-parts/coronavirus/components/custom_html.php
@@ -1,0 +1,8 @@
+<?php
+namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\CustomHTML;
+use GMUCF\Theme\Includes\Coronavirus;
+
+
+$row = Coronavirus\get_current_row();
+?>
+TODO custom html

--- a/template-parts/coronavirus/components/custom_html.php
+++ b/template-parts/coronavirus/components/custom_html.php
@@ -3,6 +3,11 @@ namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\CustomHTML;
 use GMUCF\Theme\Includes\Coronavirus;
 
 
-$row = Coronavirus\get_current_row();
+$row     = Coronavirus\get_current_row();
+$content = Coronavirus\escape_chars( $row->custom_html );
 ?>
-TODO custom html
+<tr>
+	<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.5; text-align: left; padding-bottom: 30px;" align="left">
+		<?php echo $content; ?>
+	</td>
+</tr>

--- a/template-parts/coronavirus/components/custom_html.php
+++ b/template-parts/coronavirus/components/custom_html.php
@@ -7,7 +7,7 @@ $row     = Coronavirus\get_current_row();
 $content = Coronavirus\escape_chars( $row->custom_html );
 ?>
 <tr>
-	<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.5; text-align: left; padding-bottom: 30px;" align="left">
+	<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.5; text-align: left; padding-bottom: 40px;" align="left">
 		<?php echo $content; ?>
 	</td>
 </tr>

--- a/template-parts/coronavirus/components/divider.php
+++ b/template-parts/coronavirus/components/divider.php
@@ -8,7 +8,7 @@ $color     = $row->color ?? '#ffcc00';
 $thickness = $row->thickness ?? '3px';
 ?>
 <tr>
-	<td style="padding-bottom: 30px;">
+	<td style="padding-bottom: 40px;">
 		<table style="text-align: center; width: 100%;" align="center">
 			<tbody>
 				<tr>

--- a/template-parts/coronavirus/components/divider.php
+++ b/template-parts/coronavirus/components/divider.php
@@ -3,6 +3,18 @@ namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\Divider;
 use GMUCF\Theme\Includes\Coronavirus;
 
 
-$row = Coronavirus\get_current_row();
+$row       = Coronavirus\get_current_row();
+$color     = $row->color ?? '#ffcc00';
+$thickness = $row->thickness ?? '3px';
 ?>
-TODO divider row markup
+<tr>
+	<td style="padding-bottom: 30px;">
+		<table style="text-align: center; width: 100%;" align="center">
+			<tbody>
+				<tr>
+					<td style="text-align: left; border-bottom-style: solid; height: 0; line-height: 0; max-height: 0; min-height: 0; overflow: hidden; padding: 0; width: 100%; border-bottom-width: <?php echo $thickness; ?>; border-color: <?php echo $color; ?>;" width="100%" align="left"></td>
+				</tr>
+			</tbody>
+		</table>
+	</td>
+</tr>

--- a/template-parts/coronavirus/components/divider.php
+++ b/template-parts/coronavirus/components/divider.php
@@ -1,0 +1,8 @@
+<?php
+namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\Divider;
+use GMUCF\Theme\Includes\Coronavirus;
+
+
+$row = Coronavirus\get_current_row();
+?>
+TODO divider row markup

--- a/template-parts/coronavirus/components/image.php
+++ b/template-parts/coronavirus/components/image.php
@@ -1,0 +1,8 @@
+<?php
+namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\Image;
+use GMUCF\Theme\Includes\Coronavirus;
+
+
+$row = Coronavirus\get_current_row();
+?>
+TODO image row markup

--- a/template-parts/coronavirus/components/image.php
+++ b/template-parts/coronavirus/components/image.php
@@ -11,7 +11,7 @@ $href      = $row->links_to;
 if ( $thumbnail ):
 ?>
 <tr>
-	<td style="padding-bottom: 30px;">
+	<td style="padding-bottom: 40px;">
 		<?php if ( $href ): ?>
 		<a href="<?php echo $href; ?>">
 		<?php endif; ?>

--- a/template-parts/coronavirus/components/image.php
+++ b/template-parts/coronavirus/components/image.php
@@ -4,5 +4,21 @@ use GMUCF\Theme\Includes\Coronavirus;
 
 
 $row = Coronavirus\get_current_row();
+$thumbnail = $row->thumbnail;
+$alt       = esc_attr( $row->alt_text );
+$href      = $row->links_to;
+
+if ( $thumbnail ):
 ?>
-TODO image row markup
+<tr>
+	<td style="padding-bottom: 30px;">
+		<?php if ( $href ): ?>
+		<a href="<?php echo $href; ?>">
+		<?php endif; ?>
+		<img class="img-fluid" src="<?php echo $thumbnail; ?>" alt="<?php echo $alt; ?>" style="max-width: 100%;">
+		<?php if ( $href ): ?>
+		</a>
+		<?php endif; ?>
+	</td>
+</tr>
+<?php endif; ?>

--- a/template-parts/coronavirus/components/paragraph.php
+++ b/template-parts/coronavirus/components/paragraph.php
@@ -7,7 +7,7 @@ $row     = Coronavirus\get_current_row();
 $content = Coronavirus\format_paragraph_content( $row->paragraph );
 ?>
 <tr>
-	<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.5; text-align: left; padding-bottom: 14px;" align="left">
+	<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.5; text-align: left; padding-bottom: 24px;" align="left">
 		<?php echo $content; ?>
 	</td>
 </tr>

--- a/template-parts/coronavirus/components/paragraph.php
+++ b/template-parts/coronavirus/components/paragraph.php
@@ -1,0 +1,8 @@
+<?php
+namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\Paragraph;
+use GMUCF\Theme\Includes\Coronavirus;
+
+
+$row = Coronavirus\get_current_row();
+?>
+TODO paragraph row markup

--- a/template-parts/coronavirus/components/paragraph.php
+++ b/template-parts/coronavirus/components/paragraph.php
@@ -3,6 +3,11 @@ namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\Paragraph;
 use GMUCF\Theme\Includes\Coronavirus;
 
 
-$row = Coronavirus\get_current_row();
+$row     = Coronavirus\get_current_row();
+$content = Coronavirus\format_wysiwyg_content( $row->paragraph );
 ?>
-TODO paragraph row markup
+<tr>
+	<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.5; text-align: left; padding-bottom: 14px;" align="left">
+		<?php echo $content; ?>
+	</td>
+</tr>

--- a/template-parts/coronavirus/components/paragraph.php
+++ b/template-parts/coronavirus/components/paragraph.php
@@ -4,7 +4,7 @@ use GMUCF\Theme\Includes\Coronavirus;
 
 
 $row     = Coronavirus\get_current_row();
-$content = Coronavirus\format_wysiwyg_content( $row->paragraph );
+$content = Coronavirus\format_paragraph_content( $row->paragraph );
 ?>
 <tr>
 	<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.5; text-align: left; padding-bottom: 14px;" align="left">

--- a/template-parts/coronavirus/components/two_column_row.php
+++ b/template-parts/coronavirus/components/two_column_row.php
@@ -1,0 +1,8 @@
+<?php
+namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\TwoColRow;
+use GMUCF\Theme\Includes\Coronavirus;
+
+
+$row = Coronavirus\get_current_row();
+?>
+TODO two-column row markup

--- a/template-parts/coronavirus/components/two_column_row.php
+++ b/template-parts/coronavirus/components/two_column_row.php
@@ -1,8 +1,0 @@
-<?php
-namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\TwoColRow;
-use GMUCF\Theme\Includes\Coronavirus;
-
-
-$row = Coronavirus\get_current_row();
-?>
-TODO two-column row markup

--- a/template-parts/coronavirus/mail/base.php
+++ b/template-parts/coronavirus/mail/base.php
@@ -1,0 +1,9 @@
+<?php
+namespace GMUCF\Theme\TemplateParts\Coronavirus\Mail\Base;
+use GMUCF\Theme\Includes\Coronavirus;
+
+
+echo get_template_part( 'template-parts/coronavirus/browser/header' );
+echo get_template_part( 'template-parts/coronavirus/browser/body' );
+echo get_template_part( 'template-parts/coronavirus/mail/footer' );
+?>

--- a/template-parts/coronavirus/mail/footer.php
+++ b/template-parts/coronavirus/mail/footer.php
@@ -2,4 +2,92 @@
 namespace GMUCF\Theme\TemplateParts\Coronavirus\Mail\Footer;
 use GMUCF\Theme\Includes\Coronavirus;
 ?>
-TODO mail footer
+							<tr>
+								<td style="text-align: left;" align="left">
+									<table class="container-inner" style="text-align: center; margin: auto; min-width: 580px; width: 580px;" width="580" align="center">
+										<tbody>
+											<tr>
+												<td style="text-align: left; border-bottom-style: solid; height: 0; line-height: 0; max-height: 0; min-height: 0; overflow: hidden; padding: 0; width: 100%; border-bottom-width: 3px; border-color: #fc0;" width="100%" align="left"></td>
+											</tr>
+											<tr>
+												<td style="padding-bottom: 30px; padding-top: 45px; text-align: center;" align="center">
+													<table style="text-align: center; width: auto;" align="center">
+														<tbody>
+															<tr>
+																<td style="text-align: left; padding-right: 10px;" align="left">
+																	<a href="https://www.facebook.com/ucf/">
+																		<img style="width: 42px;" width="42" src="<?php echo GMUCF_THEME_IMG_URL; ?>/social/facebook-circle.png" alt="Facebook">
+																	</a>
+																</td>
+																<td style="text-align: left; padding-right: 10px;" align="left">
+																	<a href="https://www.twitter.com/UCF/">
+																		<img style="width: 42px;" width="42" src="<?php echo GMUCF_THEME_IMG_URL; ?>/social/twitter-circle.png" alt="Twitter">
+																	</a>
+																</td>
+																<td style="text-align: left; padding-right: 10px;" align="left">
+																	<a href="https://www.instagram.com/ucf.edu">
+																		<img style="width: 42px;" width="42" src="<?php echo GMUCF_THEME_IMG_URL; ?>/social/instagram-circle.png" alt="Instagram">
+																	</a>
+																</td>
+																<td style="text-align: left; padding-right: 10px;" align="left">
+																	<a href="https://www.linkedin.com/edu/university-of-central-florida-18118">
+																		<img style="width: 42px;" width="42" src="<?php echo GMUCF_THEME_IMG_URL; ?>/social/linkedin-circle.png" alt="LinkedIn">
+																	</a>
+																</td>
+																<td style="text-align: left;" align="left">
+																	<a href="https://www.youtube.com/user/UCF/">
+																		<img style="width: 42px;" width="42" src="<?php echo GMUCF_THEME_IMG_URL; ?>/social/youtube-circle.png" alt="YouTube">
+																	</a>
+																</td>
+															</tr>
+														</tbody>
+													</table>
+												</td>
+											</tr>
+											<tr>
+												<td style="padding-bottom: 15px; text-align: center;" align="center">
+													<a href="https://www.ucf.edu/">
+														<img src="<?php echo GMUCF_THEME_IMG_URL; ?>/ucf-tab.png" style="width: 100px;" width="100" alt="UCF">
+													</a>
+												</td>
+											</tr>
+											<tr>
+												<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; text-align: center; font-size: 13px; font-weight: 700; text-transform: uppercase;" align="center">
+													<a style="color: #000; text-decoration: none; letter-spacing: 1.25px;" href="https://www.ucf.edu/">
+														University of Central Florida
+													</a>
+												</td>
+											</tr>
+											<tr>
+												<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; text-align: center; font-size: 13px;" align="center">
+													4000 Central Florida Blvd.
+												</td>
+											</tr>
+											<tr>
+												<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; text-align: center; font-size: 13px;" align="center">
+													Orlando, FL 32816
+												</td>
+											</tr>
+											<tr>
+												<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; text-align: center; font-size: 13px; padding-bottom: 45px;" align="center">
+													407-823-2000
+												</td>
+											</tr>
+											<tr>
+												<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; padding-top: 30px; padding-bottom: 45px; text-align: center; font-size: 13px;" align="center">
+													!@!UNSUBSCRIBE!@! from this email.
+												</td>
+											</tr>
+										</tbody>
+									</table>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+ 				</td>
+			</tr>
+		</tbody>
+	</table>
+
+</body>
+</html>

--- a/template-parts/coronavirus/mail/footer.php
+++ b/template-parts/coronavirus/mail/footer.php
@@ -74,7 +74,7 @@ use GMUCF\Theme\Includes\Coronavirus;
 												</td>
 											</tr>
 											<tr>
-												<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; padding-top: 30px; padding-bottom: 45px; text-align: center; font-size: 13px;" align="center">
+												<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; line-height: 1.5; padding-bottom: 45px; text-align: center; font-size: 13px;" align="center">
 													!@!UNSUBSCRIBE!@! from this email.
 												</td>
 											</tr>

--- a/template-parts/coronavirus/mail/footer.php
+++ b/template-parts/coronavirus/mail/footer.php
@@ -1,0 +1,5 @@
+<?php
+namespace GMUCF\Theme\TemplateParts\Coronavirus\Mail\Footer;
+use GMUCF\Theme\Includes\Coronavirus;
+?>
+TODO mail footer

--- a/template-parts/coronavirus/rows/one_column_row.php
+++ b/template-parts/coronavirus/rows/one_column_row.php
@@ -1,0 +1,16 @@
+<?php
+namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\Paragraph;
+use GMUCF\Theme\Includes\Coronavirus;
+
+
+$row = Coronavirus\get_current_row();
+?>
+<tr>
+	<td>
+		<table class="container-inner" style="text-align: center; margin: auto; min-width: 580px; width: 580px;" width="580" align="center">
+			<tbody>
+				<?php echo Coronavirus\display_component( $row, 'one_column_row' ); ?>
+			</tbody>
+		</table>
+	</td>
+</tr>

--- a/template-parts/coronavirus/rows/two_column_row.php
+++ b/template-parts/coronavirus/rows/two_column_row.php
@@ -1,0 +1,39 @@
+<?php
+namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\TwoColRow;
+use GMUCF\Theme\Includes\Coronavirus;
+
+
+$row = Coronavirus\get_current_row();
+?>
+<tr>
+	<td>
+		<table class="container-inner" style="text-align: center; margin: auto; min-width: 580px; width: 580px;" width="580" align="center">
+			<tbody>
+				<tr>
+					<th class="mobile-column-collapse" style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.5; text-align: left; padding-right: 15px; width: 50%; vertical-align: top;" width="50%" valign="top"  align="left">
+						<table>
+							<tbody>
+								<?php
+								foreach ( $row->column_1_contents as $subrow ) {
+									echo Coronavirus\display_component( $subrow, 'two_column_row' );
+								}
+								?>
+							</tbody>
+						</table>
+					</th>
+					<th class="mobile-column-collapse" style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.5; text-align: left; padding-left: 15px; width: 50%; vertical-align: top;" width="50%" valign="top"  align="left">
+						<table>
+							<tbody>
+								<?php
+								foreach ( $row->column_2_contents as $subrow ) {
+									echo Coronavirus\display_component( $subrow, 'two_column_row' );
+								}
+								?>
+							</tbody>
+						</table>
+					</th>
+				</tr>
+			</tbody>
+		</table>
+	</td>
+</tr>


### PR DESCRIPTION
Adds coronavirus email templates to the theme.  Options for the email are pulled in from the coronavirus website from a new REST endpoint; see https://github.com/UCF/Coronavirus-Utilities/pull/3.

Individual rows of content defined in the email builder on the CV site are abstracted into template parts--a "row" template part is rendered for every layout row defined in the builder, which then renders a "component" template part inside of it depending on the type of content defined in the row.  For instance, a row with a full-width image would be rendered in the email template by loading the `one_column_row` template part, which would then load the `image` template part within it.  A two-column row with an article in each column would render by first loading the `two_column_row` template part, then loading the `article_sm` template part within each column.