### PR TITLE
Coronavirus email UTMs

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -38,6 +38,9 @@ define( 'GMUCF_THEME_CUSTOMIZER_DEFAULTS', serialize( array(
 	'weather_service_cache_duration'   => 60 * 15, // seconds
 	'weather_service_timeout'          => 10, // seconds
 	'coronavirus_email_options_url'    => 'https://www.ucf.edu/coronavirus/wp-json/coronavirus-weekly-email/v1/options/',
+	'coronavirus_utm_source'           => 'weekly_update',
+	'coronavirus_utm_medium'           => 'email',
+	'coronavirus_utm_campaign'         => 'coronavirus',
 	'email_preview_base_list'          => ''
 ) ) );
 
@@ -601,6 +604,57 @@ function define_customizer_controls( $wp_customize ) {
 		array(
 			'label'       => 'News & Announcements - UTM Campaign',
 			'description' => 'The UTM "campaign" value to set on News & Announcement email links.',
+			'section'     => 'analytics',
+			'type'        => 'text'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'coronavirus_utm_source',
+		array (
+			'type' => 'option',
+			'default' => Utilities\get_option_default( 'coronavirus_utm_source' )
+		)
+	);
+	$wp_customize->add_control(
+		'coronavirus_utm_source',
+		array(
+			'label'       => 'Coronavirus Emails - UTM Source',
+			'description' => 'The UTM "source" value to set on Coronavirus email links.',
+			'section'     => 'analytics',
+			'type'        => 'text'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'coronavirus_utm_medium',
+		array (
+			'type' => 'option',
+			'default' => Utilities\get_option_default( 'coronavirus_utm_medium' )
+		)
+	);
+	$wp_customize->add_control(
+		'coronavirus_utm_medium',
+		array(
+			'label'       => 'Coronavirus Emails - UTM Medium',
+			'description' => 'The UTM "medium" value to set on Coronavirus email links.',
+			'section'     => 'analytics',
+			'type'        => 'text'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'coronavirus_utm_campaign',
+		array (
+			'type' => 'option',
+			'default' => Utilities\get_option_default( 'coronavirus_utm_campaign' )
+		)
+	);
+	$wp_customize->add_control(
+		'coronavirus_utm_campaign',
+		array(
+			'label'       => 'Coronavirus Emails - UTM Campaign',
+			'description' => 'The UTM "campaign" value to set on Coronavirus email links.',
 			'section'     => 'analytics',
 			'type'        => 'text'
 		)

--- a/includes/config.php
+++ b/includes/config.php
@@ -41,6 +41,7 @@ define( 'GMUCF_THEME_CUSTOMIZER_DEFAULTS', serialize( array(
 	'coronavirus_utm_source'           => 'weekly_update',
 	'coronavirus_utm_medium'           => 'email',
 	'coronavirus_utm_campaign'         => 'coronavirus',
+	'coronavirus_header_utm_content'   => 'header_image',
 	'email_preview_base_list'          => ''
 ) ) );
 
@@ -620,7 +621,7 @@ function define_customizer_controls( $wp_customize ) {
 		'coronavirus_utm_source',
 		array(
 			'label'       => 'Coronavirus Emails - UTM Source',
-			'description' => 'The UTM "source" value to set on Coronavirus email links.',
+			'description' => 'The UTM "source" value to set on links within Coronavirus email content.',
 			'section'     => 'analytics',
 			'type'        => 'text'
 		)
@@ -637,7 +638,7 @@ function define_customizer_controls( $wp_customize ) {
 		'coronavirus_utm_medium',
 		array(
 			'label'       => 'Coronavirus Emails - UTM Medium',
-			'description' => 'The UTM "medium" value to set on Coronavirus email links.',
+			'description' => 'The UTM "medium" value to set on links within Coronavirus email content.',
 			'section'     => 'analytics',
 			'type'        => 'text'
 		)
@@ -654,7 +655,24 @@ function define_customizer_controls( $wp_customize ) {
 		'coronavirus_utm_campaign',
 		array(
 			'label'       => 'Coronavirus Emails - UTM Campaign',
-			'description' => 'The UTM "campaign" value to set on Coronavirus email links.',
+			'description' => 'The UTM "campaign" value to set on links within Coronavirus email content.',
+			'section'     => 'analytics',
+			'type'        => 'text'
+		)
+	);
+
+	$wp_customize->add_setting(
+		'coronavirus_header_utm_content',
+		array (
+			'type' => 'option',
+			'default' => Utilities\get_option_default( 'coronavirus_header_utm_content' )
+		)
+	);
+	$wp_customize->add_control(
+		'coronavirus_header_utm_content',
+		array(
+			'label'       => 'Coronavirus Email Header - UTM Content',
+			'description' => 'The UTM "content" value to set on the Coronavirus email header.',
 			'section'     => 'analytics',
 			'type'        => 'text'
 		)

--- a/includes/coronavirus-functions.php
+++ b/includes/coronavirus-functions.php
@@ -131,6 +131,7 @@ function format_paragraph_content( $content ) {
 	$content = \convert_li_tags( $content );
 	$content = convert_heading_tags( $content, 'h2', '24px' );
 	$content = convert_heading_tags( $content, 'h3', '18px' );
+	$content = apply_link_utm_params( $content ); // namespaced function--not Email Editor Plugin's function
 	$content = escape_chars( $content );
 
 	return $content;
@@ -208,4 +209,42 @@ function convert_heading_tags( $content, $heading_elem, $font_size ) {
  */
 function escape_chars( $content ) {
 	return htmlspecialchars_decode( htmlentities( $content ) );
+}
+
+
+/**
+ * Wrapper for the UCF Email Editor Plugin's
+ * `format_url_utm_params()` function, using params
+ * for Coronavirus emails defined in the Customizer.
+ *
+ * @since 3.1.1
+ * @author Jo Dickson
+ * @param string $url Arbitrary URL
+ * @return string Formatted URL
+ */
+function format_url_utm_params( $url ) {
+	$source   = get_option( 'coronavirus_utm_source' );
+	$medium   = get_option( 'coronavirus_utm_medium' );
+	$campaign = get_option( 'coronavirus_utm_campaign' );
+
+	return \format_url_utm_params( $url, $source, $medium, $campaign );
+}
+
+
+/**
+ * Wrapper for the UCF Email Editor Plugin's
+ * `apply_link_utm_params()` function, using params
+ * for Coronavirus emails defined in the Customizer.
+ *
+ * @since 3.1.1
+ * @author Jo Dickson
+ * @param string $str Arbitrary HTML string
+ * @return string Modified HTML string
+ */
+function apply_link_utm_params( $str ) {
+	$source   = get_option( 'coronavirus_utm_source' );
+	$medium   = get_option( 'coronavirus_utm_medium' );
+	$campaign = get_option( 'coronavirus_utm_campaign' );
+
+	return \apply_link_utm_params( $str, $source, $medium, $campaign );
 }

--- a/includes/coronavirus-functions.php
+++ b/includes/coronavirus-functions.php
@@ -223,11 +223,17 @@ function escape_chars( $content ) {
  * @return string Formatted URL
  */
 function format_url_utm_params( $url ) {
-	$source   = get_option( 'coronavirus_utm_source' );
-	$medium   = get_option( 'coronavirus_utm_medium' );
-	$campaign = get_option( 'coronavirus_utm_campaign' );
+	$pattern = \UCF_Email_Editor_Config::get_option_or_default( 'utm_replace_regex' );
 
-	return \format_url_utm_params( $url, $source, $medium, $campaign );
+	if ( preg_match( $pattern, $url ) ) {
+		$source   = get_option( 'coronavirus_utm_source' );
+		$medium   = get_option( 'coronavirus_utm_medium' );
+		$campaign = get_option( 'coronavirus_utm_campaign' );
+
+		$url = \format_url_utm_params( $url, $source, $medium, $campaign );
+	}
+
+	return $url;
 }
 
 

--- a/includes/coronavirus-functions.php
+++ b/includes/coronavirus-functions.php
@@ -222,15 +222,16 @@ function escape_chars( $content ) {
  * @param string $url Arbitrary URL
  * @return string Formatted URL
  */
-function format_url_utm_params( $url ) {
+function format_url_utm_params( $url, $utm_content='' ) {
 	$pattern = \UCF_Email_Editor_Config::get_option_or_default( 'utm_replace_regex' );
 
 	if ( preg_match( $pattern, $url ) ) {
 		$source   = get_option( 'coronavirus_utm_source' );
 		$medium   = get_option( 'coronavirus_utm_medium' );
 		$campaign = get_option( 'coronavirus_utm_campaign' );
+		$content  = $utm_content;
 
-		$url = \format_url_utm_params( $url, $source, $medium, $campaign );
+		$url = \format_url_utm_params( $url, $source, $medium, $campaign, $content );
 	}
 
 	return $url;

--- a/includes/coronavirus-functions.php
+++ b/includes/coronavirus-functions.php
@@ -125,13 +125,15 @@ function get_current_row() {
  * @return string Formatted content
  */
 function format_paragraph_content( $content ) {
+	$current_date = current_datetime();
+
 	$content = \convert_p_tags( $content );
 	$content = \convert_list_tags( $content, 'ul' );
 	$content = \convert_list_tags( $content, 'ol' );
 	$content = \convert_li_tags( $content );
 	$content = convert_heading_tags( $content, 'h2', '24px' );
 	$content = convert_heading_tags( $content, 'h3', '18px' );
-	$content = apply_link_utm_params( $content ); // namespaced function--not Email Editor Plugin's function
+	$content = apply_link_utm_params( $content, $current_date->format( 'Y-m-d' ) ); // namespaced function--not Email Editor Plugin's function
 	$content = escape_chars( $content );
 
 	return $content;
@@ -220,16 +222,16 @@ function escape_chars( $content ) {
  * @since 3.1.1
  * @author Jo Dickson
  * @param string $url Arbitrary URL
+ * @param string $content utm_content param to insert into the URL
  * @return string Formatted URL
  */
-function format_url_utm_params( $url, $utm_content='' ) {
+function format_url_utm_params( $url, $content='' ) {
 	$pattern = \UCF_Email_Editor_Config::get_option_or_default( 'utm_replace_regex' );
 
 	if ( preg_match( $pattern, $url ) ) {
 		$source   = get_option( 'coronavirus_utm_source' );
 		$medium   = get_option( 'coronavirus_utm_medium' );
 		$campaign = get_option( 'coronavirus_utm_campaign' );
-		$content  = $utm_content;
 
 		$url = \format_url_utm_params( $url, $source, $medium, $campaign, $content );
 	}
@@ -246,12 +248,13 @@ function format_url_utm_params( $url, $utm_content='' ) {
  * @since 3.1.1
  * @author Jo Dickson
  * @param string $str Arbitrary HTML string
+ * @param string $content utm_content param to insert into URLs
  * @return string Modified HTML string
  */
-function apply_link_utm_params( $str ) {
+function apply_link_utm_params( $str, $content='' ) {
 	$source   = get_option( 'coronavirus_utm_source' );
 	$medium   = get_option( 'coronavirus_utm_medium' );
 	$campaign = get_option( 'coronavirus_utm_campaign' );
 
-	return \apply_link_utm_params( $str, $source, $medium, $campaign );
+	return \apply_link_utm_params( $str, $source, $medium, $campaign, $content );
 }

--- a/template-parts/coronavirus/browser/header.php
+++ b/template-parts/coronavirus/browser/header.php
@@ -3,11 +3,12 @@ namespace GMUCF\Theme\TemplateParts\Coronavirus\Browser\Header;
 use GMUCF\Theme\Includes\Coronavirus;
 
 
-$current_date   = current_datetime();
-$options        = Coronavirus\fetch_options_data();
-$title          = isset( $options->title ) ? Coronavirus\escape_chars( $options->title ) : '';
-$header_img     = $options->header_image ?? null;
-$header_img_url = isset( $options->header_image_link ) ? Coronavirus\format_url_utm_params( $options->header_image_link ) : null;
+$current_date           = current_datetime();
+$options                = Coronavirus\fetch_options_data();
+$title                  = isset( $options->title ) ? Coronavirus\escape_chars( $options->title ) : '';
+$header_img             = $options->header_image ?? null;
+$header_img_utm_content = get_option( 'coronavirus_header_utm_content' ) ?: '';
+$header_img_url         = isset( $options->header_image_link ) ? Coronavirus\format_url_utm_params( $options->header_image_link, $header_img_utm_content ) : null;
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html lang="en">

--- a/template-parts/coronavirus/browser/header.php
+++ b/template-parts/coronavirus/browser/header.php
@@ -7,7 +7,7 @@ $current_date   = current_datetime();
 $options        = Coronavirus\fetch_options_data();
 $title          = isset( $options->title ) ? Coronavirus\escape_chars( $options->title ) : '';
 $header_img     = $options->header_image ?? null;
-$header_img_url = $options->header_image_link ?? null;
+$header_img_url = isset( $options->header_image_link ) ? Coronavirus\format_url_utm_params( $options->header_image_link ) : null;
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html lang="en">

--- a/template-parts/coronavirus/components/article.php
+++ b/template-parts/coronavirus/components/article.php
@@ -7,7 +7,7 @@ $row = Coronavirus\get_current_row();
 $thumbnail = $row->thumbnail;
 $title     = Coronavirus\escape_chars( $row->article_title );
 $deck      = Coronavirus\format_deck_content( $row->article_deck );
-$href      = $row->links_to;
+$href      = Coronavirus\format_url_utm_params( $row->links_to );
 ?>
 <tr>
 	<td style="text-align: left; padding-bottom: 40px;" align="left">

--- a/template-parts/coronavirus/components/article.php
+++ b/template-parts/coronavirus/components/article.php
@@ -3,11 +3,12 @@ namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\Article;
 use GMUCF\Theme\Includes\Coronavirus;
 
 
-$row = Coronavirus\get_current_row();
-$thumbnail = $row->thumbnail;
-$title     = Coronavirus\escape_chars( $row->article_title );
-$deck      = Coronavirus\format_deck_content( $row->article_deck );
-$href      = Coronavirus\format_url_utm_params( $row->links_to );
+$current_date = current_datetime();
+$row          = Coronavirus\get_current_row();
+$thumbnail    = $row->thumbnail;
+$title        = Coronavirus\escape_chars( $row->article_title );
+$deck         = Coronavirus\format_deck_content( $row->article_deck );
+$href         = Coronavirus\format_url_utm_params( $row->links_to, $current_date->format( 'Y-m-d' ) );
 ?>
 <tr>
 	<td style="text-align: left; padding-bottom: 40px;" align="left">

--- a/template-parts/coronavirus/components/article_list.php
+++ b/template-parts/coronavirus/components/article_list.php
@@ -3,7 +3,8 @@ namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\ArticleList;
 use GMUCF\Theme\Includes\Coronavirus;
 
 
-$row = Coronavirus\get_current_row();
+$current_date = current_datetime();
+$row          = Coronavirus\get_current_row();
 ?>
 <tr>
 	<td style="text-align: left; padding-bottom: 10px;" align="left">
@@ -14,7 +15,7 @@ $row = Coronavirus\get_current_row();
 					$thumbnail = $article->thumbnail;
 					$title     = Coronavirus\escape_chars( $article->article_title );
 					$deck      = Coronavirus\format_deck_content( $article->article_deck );
-					$href      = Coronavirus\format_url_utm_params( $article->links_to );
+					$href      = Coronavirus\format_url_utm_params( $article->links_to, $current_date->format( 'Y-m-d' ) );
 				?>
 				<tr>
 					<td style="text-align: left; padding-bottom: 30px;" align="left">

--- a/template-parts/coronavirus/components/article_list.php
+++ b/template-parts/coronavirus/components/article_list.php
@@ -14,7 +14,7 @@ $row = Coronavirus\get_current_row();
 					$thumbnail = $article->thumbnail;
 					$title     = Coronavirus\escape_chars( $article->article_title );
 					$deck      = Coronavirus\format_deck_content( $article->article_deck );
-					$href      = $article->links_to;
+					$href      = Coronavirus\format_url_utm_params( $article->links_to );
 				?>
 				<tr>
 					<td style="text-align: left; padding-bottom: 30px;" align="left">

--- a/template-parts/coronavirus/components/article_sm.php
+++ b/template-parts/coronavirus/components/article_sm.php
@@ -3,11 +3,12 @@ namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\Article;
 use GMUCF\Theme\Includes\Coronavirus;
 
 
-$row       = Coronavirus\get_current_row();
-$thumbnail = $row->thumbnail;
-$title     = Coronavirus\escape_chars( $row->article_title );
-$deck      = Coronavirus\format_deck_content( $row->article_deck );
-$href      = Coronavirus\format_url_utm_params( $row->links_to );
+$current_date = current_datetime();
+$row          = Coronavirus\get_current_row();
+$thumbnail    = $row->thumbnail;
+$title        = Coronavirus\escape_chars( $row->article_title );
+$deck         = Coronavirus\format_deck_content( $row->article_deck );
+$href         = Coronavirus\format_url_utm_params( $row->links_to, $current_date->format( 'Y-m-d' ) );
 ?>
 <tr>
 	<td style="text-align: left; padding-bottom: 40px;" align="left">

--- a/template-parts/coronavirus/components/article_sm.php
+++ b/template-parts/coronavirus/components/article_sm.php
@@ -7,7 +7,7 @@ $row       = Coronavirus\get_current_row();
 $thumbnail = $row->thumbnail;
 $title     = Coronavirus\escape_chars( $row->article_title );
 $deck      = Coronavirus\format_deck_content( $row->article_deck );
-$href      = $row->links_to;
+$href      = Coronavirus\format_url_utm_params( $row->links_to );
 ?>
 <tr>
 	<td style="text-align: left; padding-bottom: 40px;" align="left">

--- a/template-parts/coronavirus/components/custom_html.php
+++ b/template-parts/coronavirus/components/custom_html.php
@@ -4,7 +4,7 @@ use GMUCF\Theme\Includes\Coronavirus;
 
 
 $row     = Coronavirus\get_current_row();
-$content = Coronavirus\escape_chars( $row->custom_html );
+$content = Coronavirus\escape_chars( Coronavirus\apply_link_utm_params( $row->custom_html ) );
 ?>
 <tr>
 	<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.5; text-align: left; padding-bottom: 40px;" align="left">

--- a/template-parts/coronavirus/components/custom_html.php
+++ b/template-parts/coronavirus/components/custom_html.php
@@ -3,8 +3,9 @@ namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\CustomHTML;
 use GMUCF\Theme\Includes\Coronavirus;
 
 
-$row     = Coronavirus\get_current_row();
-$content = Coronavirus\escape_chars( Coronavirus\apply_link_utm_params( $row->custom_html ) );
+$current_date = current_datetime();
+$row          = Coronavirus\get_current_row();
+$content      = Coronavirus\escape_chars( Coronavirus\apply_link_utm_params( $row->custom_html, $current_date->format( 'Y-m-d' ) ) );
 ?>
 <tr>
 	<td style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.5; text-align: left; padding-bottom: 40px;" align="left">

--- a/template-parts/coronavirus/components/image.php
+++ b/template-parts/coronavirus/components/image.php
@@ -3,10 +3,11 @@ namespace GMUCF\Theme\TemplateParts\Coronavirus\Components\Image;
 use GMUCF\Theme\Includes\Coronavirus;
 
 
-$row = Coronavirus\get_current_row();
-$thumbnail = $row->thumbnail;
-$alt       = esc_attr( $row->alt_text );
-$href      = Coronavirus\format_url_utm_params( $row->links_to );
+$current_date = current_datetime();
+$row          = Coronavirus\get_current_row();
+$thumbnail    = $row->thumbnail;
+$alt          = esc_attr( $row->alt_text );
+$href         = Coronavirus\format_url_utm_params( $row->links_to, $current_date->format( 'Y-m-d' ) );
 
 if ( $thumbnail ):
 ?>

--- a/template-parts/coronavirus/components/image.php
+++ b/template-parts/coronavirus/components/image.php
@@ -6,7 +6,7 @@ use GMUCF\Theme\Includes\Coronavirus;
 $row = Coronavirus\get_current_row();
 $thumbnail = $row->thumbnail;
 $alt       = esc_attr( $row->alt_text );
-$href      = $row->links_to;
+$href      = Coronavirus\format_url_utm_params( $row->links_to );
 
 if ( $thumbnail ):
 ?>


### PR DESCRIPTION
Added UTM params to *.ucf.edu links in the Coronavirus email contents and the header image link.

Params are editable via the Customizer.  All CV links share the same `utm_source`, `utm_medium` and `utm_campaign`, but the header image link has a custom configurable `utm_content`, and links in the email content will have their `utm_content` value set to the current date (YYYY-MM-DD).