### PR TITLE
Coronavirus email - image dimension fix

### DIFF
--- a/includes/coronavirus-functions.php
+++ b/includes/coronavirus-functions.php
@@ -89,6 +89,9 @@ function display_component( $row, $row_type='one_column_row' ) {
 	if ( $row_type === 'two_column_row' && $component === 'article' ) {
 		$component = 'article_sm';
 	}
+	else if ( $row_type === 'two_column_row' && $component === 'image' ) {
+		$component = 'image_sm';
+	}
 
 	// Pass along $row data to the template part:
 	set_query_var( 'gmucf_coronavirus_current_row', $row );

--- a/template-parts/coronavirus/browser/header.php
+++ b/template-parts/coronavirus/browser/header.php
@@ -186,7 +186,7 @@ img {
 									<?php if ( $header_img_url ): ?>
 									<a href="<?php echo $header_img_url; ?>">
 									<?php endif; ?>
-										<img class="img-fluid" src="<?php echo $header_img; ?>" alt="UCF Coronavirus Information" style="max-width: 100%;">
+										<img class="img-fluid" width="640" src="<?php echo $header_img; ?>" alt="UCF Coronavirus Information" style="max-width: 100%;">
 									<?php if ( $header_img_url ): ?>
 									</a>
 									<?php endif; ?>

--- a/template-parts/coronavirus/components/image_sm.php
+++ b/template-parts/coronavirus/components/image_sm.php
@@ -16,7 +16,7 @@ if ( $thumbnail ):
 		<?php if ( $href ): ?>
 		<a href="<?php echo $href; ?>">
 		<?php endif; ?>
-		<img class="img-fluid" width="580" src="<?php echo $thumbnail; ?>" alt="<?php echo $alt; ?>" style="max-width: 100%;">
+		<img class="img-fluid" width="275" src="<?php echo $thumbnail; ?>" alt="<?php echo $alt; ?>" style="max-width: 100%;">
 		<?php if ( $href ): ?>
 		</a>
 		<?php endif; ?>


### PR DESCRIPTION
- Added a new `image_sm.php` component template part for images included in two-column rows.
- Updated `<img>` tags in both image template parts and the email header template to ensure a `width` attribute is set (for Outlook compatibility)